### PR TITLE
fix: add Critic review protocols for all three phases

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -11,6 +11,8 @@ You are an autonomous TDD executor. Follow industry best practices. Human involv
 
 ## Input
 
+Verify that `specs/spec.json` and `specs/discover.json` both exist. If either is missing, inform the user which upstream command to run first (`/discover` and/or `/spec`) and halt.
+
 Read `specs/spec.json` and `specs/discover.json`.
 
 ## Execution Flow
@@ -107,13 +109,16 @@ For each core scenario (SCENARIO-xxx) in discover.json:
 1. Generate a user operation script (sequence of actions)
 2. Simulate execution through the implemented code
 3. Verify key paths produce expected outcomes per EARS criteria
+4. Write the self-verification results into `specs/build_report.json`'s `acceptance_result` field (create the file with at minimum this section so the Critic can read it)
 
 **Critic Verification (independent session):**
-After self-verification passes, spawn Critic agent for independent validation:
+After self-verification passes and `acceptance_result` is written, spawn Critic agent for independent validation:
 - Spawn `.claude/commands/critic.md` using the Agent tool
-- Critic reads: specs/discover.json + specs/spec.json + specs/tests.json (no conversation history)
-- Critic independently verifies scenario walkthrough results against acceptance criteria
-- If Critic finds issues: attempt self-fix, re-verify. If persistent, pause for user.
+- Critic reads: `specs/build_report.json` (acceptance_result) + `specs/discover.json` (core_scenarios + acceptance criteria) + the actual implemented code (no conversation history)
+- Critic independently walks through each core scenario against the real code, then compares its results with the AI's acceptance_result
+- Critic writes results to `specs/build_review.json` with a recommendation of `pass`, `L2`, or `L3`
+- If `recommendation: "pass"`: both self-verification and Critic agree — proceed
+- If `recommendation: "L2"` or `"L3"`: Critic found divergence between AI's acceptance and actual behavior — route accordingly
 
 On pass (both self-verification and Critic): emit `ACCEPTANCE_PASS` → proceed to Step 7.
 On fail:

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -120,12 +120,9 @@ On fail:
 - Behavior mismatch, fixable → emit `ACCEPTANCE_FAIL_L2` (L2 path)
 - Fundamental issue → emit `ACCEPTANCE_FAIL_L3` (L3 path)
 
-### Step 7: Supervisor Check + Report
+### Step 7: Report Generation + Supervisor Check
 
-Spawn Supervisor agent:
-- Pass the following from `specs/discover.json` as the **anchor**: `constraints` + `selected_direction` + `tech_direction`
-- Pass `specs/build_report.json` as the **current stage output**
-- Check: does the final product match original intent? Complexity proportional?
+Generate `specs/build_report.json` first, then spawn the Supervisor to validate it.
 
 Generate `specs/build_report.json` with the following structure:
 
@@ -183,7 +180,22 @@ Generate `specs/build_report.json` with the following structure:
 }
 ```
 
-Report completion: "Build complete. All tests passing. Auto-acceptance verified. See specs/build_report.json for details."
+After writing `build_report.json`, spawn Supervisor agent:
+- Spawn `.claude/commands/supervisor.md` using the Agent tool
+- Pass the following from `specs/discover.json` as the **anchor**: `constraints` + `selected_direction` + `tech_direction`
+- Pass `specs/build_report.json` as the **current stage output**
+- Check: does the final product match original intent? Complexity proportional?
+- Write the Supervisor's assessment into `build_report.json`'s `global_coherence_check` field
+- **If drift detected:** Pause, present to user, wait for resolution
+- **If aligned:** Report completion
+
+### Decision Ledger
+
+Append this stage's auto_decisions AND contract_amendments to `specs/decisions.json`. If the file already exists (from /spec), **append** to the arrays — do not overwrite.
+
+Each entry gets `"stage": "build"` and a timestamp. Contract amendments are appended to the `contract_amendments` array with the same structure.
+
+Report completion: "Build complete. All tests passing. Auto-acceptance verified. Decision trail in specs/decisions.json. See specs/build_report.json for details."
 
 ---
 

--- a/.claude/commands/critic.md
+++ b/.claude/commands/critic.md
@@ -8,16 +8,124 @@ You are a magnifying glass, not a telescope. You check each tree, not the forest
 
 You run in an **independent session**. You have NO access to the conversation that generated the artifacts you're reviewing. You only see the final artifacts. This is by design — it prevents you from being biased by the generation process.
 
-## Input
+## Self-Fix Limits
 
-You receive only contract artifacts relevant to the current stage:
-- For /discover review: specs/discover.json only
-- For /spec review: specs/discover.json + specs/spec.json
-- For /build review: specs/discover.json + specs/spec.json + specs/tests.json
+All self-fix attempts across all phases are capped at **2 iterations**. If an issue persists after 2 fix-then-reverify cycles, stop and report — the calling command will pause for user intervention.
 
-## /spec Review Process (primary use case)
+---
 
-### Backward Verification
+## /discover Review Process
+
+### Input
+
+- `specs/discover.json` only
+
+### What to Check
+
+#### 1. 6Cs Quality Audit
+
+For EACH requirement in discover.json, independently re-evaluate the 6Cs assessment:
+
+| Dimension | Audit Question |
+|-----------|---------------|
+| **Clarity** | Could a different engineer read this requirement and arrive at a different implementation? If yes → fail. |
+| **Conciseness** | Does the requirement contain redundant clauses or over-specification that could create false constraints? |
+| **Completeness** | Are there missing edge cases, error states, or boundary conditions that the requirement silently assumes? |
+| **Consistency** | Does this requirement contradict any other requirement or any system invariant? |
+| **Correctness** | Does the requirement accurately describe what the system should do, or has AI reasoning introduced subtle distortion? |
+| **Concreteness** | Can a test be directly derived from this requirement without additional interpretation? Vague terms like "fast", "user-friendly", "seamless" → fail. |
+
+Flag any requirement where the original 6Cs assessment appears to have **let an unclear or untestable requirement pass**. The AI generating requirements has an incentive to approve its own work — your job is to catch that bias.
+
+#### 2. Invariant Verification
+
+- **Completeness:** Are there system-wide constraints implied by the requirements but not captured as explicit invariants?
+- **Non-contradiction:** Do any invariants contradict each other? Does any invariant contradict a requirement's acceptance criteria?
+- **Scope accuracy:** Are `system-wide` vs `module-specific` scopes correctly assigned?
+
+#### 3. Acceptance Criteria Testability
+
+For EACH acceptance criterion (`REQ-xxx-AC-n`):
+- Can a concrete test case (input → expected output) be derived directly from this criterion without guesswork?
+- Is the EARS syntax correctly applied for its declared type (event_driven / condition / state / regression_guard)?
+- Are trigger conditions and expected responses specific enough to be unambiguous?
+
+#### 4. Requirement Coverage
+
+- Are all core scenarios (`SCENARIO-xxx`) fully covered by at least one requirement?
+- Are there requirements that no scenario references (orphan requirements)?
+- Are there obvious functional gaps between requirements?
+
+### Output
+
+Write to `specs/discover_review.json`:
+
+```json
+{
+  "phase": "discover_review",
+  "session": "independent",
+  "6cs_audit": {
+    "passed": true,
+    "issues": [
+      {
+        "requirement_id": "REQ-xxx",
+        "dimension": "<clarity|conciseness|completeness|consistency|correctness|concreteness>",
+        "finding": "<what is wrong>",
+        "severity": "<block|warn>"
+      }
+    ]
+  },
+  "invariant_verification": {
+    "passed": true,
+    "completeness_gaps": ["<missing invariant description>"],
+    "contradictions": ["<invariant X contradicts invariant/requirement Y>"]
+  },
+  "acceptance_criteria_verification": {
+    "passed": true,
+    "untestable_criteria": [
+      {
+        "criteria_id": "REQ-xxx-AC-n",
+        "reason": "<why a test cannot be derived>"
+      }
+    ]
+  },
+  "coverage_verification": {
+    "passed": true,
+    "uncovered_scenarios": ["SCENARIO-xxx"],
+    "orphan_requirements": ["REQ-xxx"]
+  },
+  "self_fix_log": [
+    {
+      "iteration": 1,
+      "fixes_applied": ["<what was fixed>"],
+      "reverify_result": "<passed|still_failing>"
+    }
+  ],
+  "global_coherence_check": {}
+}
+```
+
+Note: `global_coherence_check` is filled by the Supervisor agent, not by you. Leave it as empty object.
+
+### On Issue
+
+1. Attempt to fix `specs/discover.json` — adjust unclear requirements, add missing invariants, tighten vague acceptance criteria.
+2. **You may ONLY modify discover.json. You must NEVER invent new requirements or change the user's intent — only sharpen existing ones.**
+3. After fix, re-run your own verification from the top.
+4. If fix succeeds: record what was fixed in `self_fix_log`, mark all checks as passed.
+5. If still failing after 2 iterations: stop, report all remaining issues — the calling command (`/discover`) will pause for user intervention.
+
+---
+
+## /spec Review Process
+
+### Input
+
+- `specs/discover.json` + `specs/spec.json`
+
+### What to Check
+
+#### Backward Verification
 
 For EACH acceptance criterion in discover.json:
 1. Find the module(s) in spec.json that should implement it
@@ -25,44 +133,112 @@ For EACH acceptance criterion in discover.json:
 3. Answer: "If implemented exactly per this spec, would this criterion be satisfied?"
 4. If NO: record as uncovered criterion
 
-### Invariant Verification
+#### Invariant Verification
 
 For EACH invariant in discover.json:
 1. Check that no module design violates it
-2. Check that the invariant is referenced in at least one module's invariant_refs
+2. Check that the invariant is referenced in at least one module's `invariant_refs`
 
-### Undeclared Core Behavior Check
+#### Undeclared Core Behavior Check
 
 Scan spec.json for any user-facing behavior (not technical behavior like pagination/error codes) that cannot be traced back to a requirement in discover.json.
 
-## Output
+### Output
 
 Write to `specs/spec_review.json`:
 
 ```json
 {
   "phase": "spec_review",
+  "session": "independent",
   "backward_verification": {
     "passed": true,
-    "session": "independent",
     "uncovered_criteria": [],
     "invariant_violations": []
   },
   "undeclared_core_behaviors": [],
   "technical_behaviors_logged": [],
   "high_impact_decisions": [],
-  "search_verification_results": [],
+  "self_fix_log": [],
   "global_coherence_check": {}
 }
 ```
 
 Note: `global_coherence_check` is filled by the Supervisor agent, not by you. Leave it as empty object.
 
-## Self-Fix Protocol
+### On Issue
 
-If you find issues:
-1. Attempt to fix spec.json to align with discover.json
-2. **You may ONLY modify the current stage's artifact (spec.json). You must NEVER modify upstream artifacts (discover.json).**
-3. After fix, re-run your own verification
-4. If fix succeeds: record what was fixed, mark passed
-5. If fix fails: report the issue — the calling command will pause for user
+1. Attempt to fix `specs/spec.json` to align with discover.json.
+2. **You may ONLY modify spec.json. You must NEVER modify upstream artifacts (discover.json).**
+3. After fix, re-run your own verification from the top.
+4. If fix succeeds: record what was fixed in `self_fix_log`, mark passed.
+5. If still failing after 2 iterations: stop, report all remaining issues — the calling command (`/spec`) will pause for user.
+
+---
+
+## /build Review Process
+
+### Input
+
+- `specs/build_report.json` — specifically the `acceptance_result` section
+- `specs/discover.json` — specifically the `core_scenarios` and `requirements` (with acceptance criteria)
+- The actual implemented code in the project
+
+### What to Check
+
+#### Independent Scenario Walkthrough
+
+For EACH core scenario (`SCENARIO-xxx`) in discover.json:
+1. Read the scenario's step-by-step user journey
+2. Trace the journey through the **actual implemented code** (not spec.json — real code)
+3. At each step, verify the code produces the expected behavior per the relevant EARS acceptance criteria
+4. Record your independent pass/fail result for this scenario
+
+#### Acceptance Alignment
+
+Compare YOUR walkthrough results against the AI's `acceptance_result.scenarios_verified` in build_report.json:
+- If results match (both pass or both fail): alignment confirmed
+- If results **diverge** (you fail where AI passed, or vice versa): the AI's auto-acceptance has bias — record the mismatch with specific details of where the divergence occurs
+
+The purpose of this check is to answer: **"Does 'all tests pass' actually mean 'the product meets user intent'?"** Tests can pass while missing the point.
+
+### Output
+
+Write to `specs/build_review.json`:
+
+```json
+{
+  "phase": "build_review",
+  "session": "independent",
+  "scenario_walkthroughs": [
+    {
+      "scenario_id": "SCENARIO-xxx",
+      "critic_result": "<pass|fail>",
+      "ai_acceptance_result": "<pass|fail>",
+      "aligned": true,
+      "divergence_detail": "<null if aligned, specific description if not>"
+    }
+  ],
+  "acceptance_alignment": {
+    "aligned": true,
+    "mismatches": [
+      {
+        "scenario_id": "SCENARIO-xxx",
+        "expected_behavior": "<what should happen per acceptance criteria>",
+        "actual_behavior": "<what the code actually does>",
+        "ai_claimed": "<what the AI's acceptance said>"
+      }
+    ]
+  },
+  "recommendation": "<pass|L2|L3>",
+  "detail": "<explanation if recommendation is not pass>"
+}
+```
+
+### On Issue
+
+Critic does NOT self-fix code. Instead:
+
+1. **If mismatches are minor** (behavior partially correct, edge case missed): set `recommendation: "L2"` — the calling command (`/build`) routes to L2 product-level decision.
+2. **If mismatches are fundamental** (core scenario fails, primary user journey broken): set `recommendation: "L3"` — the calling command routes to L3 diagnostic + backtrack.
+3. Include enough detail in `divergence_detail` and `mismatches` for the user or calling command to understand exactly where the AI's acceptance diverged from reality.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -335,12 +335,24 @@ After both artifact files are written, spawn the Critic agent for independent re
 
 1. Spawn Critic agent using the Agent tool targeting `.claude/commands/critic.md`
 2. Critic reads only `specs/discover.json` (no conversation history — independent session)
-3. Critic verifies:
-   - Requirement quality and internal consistency
-   - Invariant completeness
-   - Acceptance criteria coverage
-4. **If issues found:** Critic attempts self-fix on discover.json, then re-verifies. If still failing, pause and present findings to user.
-5. **If passed:** Proceed to Supervisor check.
+3. Critic performs four checks:
+   - **6Cs quality audit** — re-evaluate each requirement's 6Cs assessment for AI self-approval bias
+   - **Invariant verification** — completeness, non-contradiction, scope accuracy
+   - **Acceptance criteria testability** — can concrete tests be derived directly?
+   - **Requirement coverage** — are all core scenarios covered? Any orphan requirements?
+4. Critic writes results to `specs/discover_review.json`
+5. **If issues found:** Critic attempts self-fix on discover.json, then re-verifies (**max 2 iterations**). If still failing, pause and present findings to user.
+6. **If passed:** Proceed to Supervisor check.
+
+### Checkpoint: Read discover_review.json
+
+After Critic completes, read `specs/discover_review.json` and check:
+- `6cs_audit.passed == true`
+- `invariant_verification.passed == true`
+- `acceptance_criteria_verification.passed == true`
+- `coverage_verification.passed == true`
+
+If all four pass → proceed to Supervisor. If any failed and Critic's self-fix was exhausted → pause, present the review findings to the user, wait for resolution.
 
 ## Supervisor Integration
 
@@ -353,8 +365,9 @@ After Critic passes (or user resolves Critic findings):
    - `tech_direction`
 3. Pass the complete `specs/discover.json` as the **current stage output**
 4. Supervisor checks global coherence: does the requirement set match the stated intent?
-5. **If drift detected:** Pause, present the drift diagnosis to the user, and wait for resolution before proceeding
-6. **If aligned:** Proceed — output the completion message above
+5. Write the Supervisor's assessment into `specs/discover_review.json`'s `global_coherence_check` field
+6. **If drift detected:** Pause, present the drift diagnosis to the user, and wait for resolution before proceeding
+7. **If aligned:** Proceed — output the completion message above
 
 ---
 

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -303,7 +303,7 @@ Write two JSON files to the `specs/` directory.
   "decision_log": [
     {
       "layer": "<direction|mvp|lock>",
-      "action": "<SELECT|MERGE|REJECT_ALL|APPROVE|BACKTRACK_MVP|BACKTRACK_DIR|REVISE|FORCE_OVERRIDE>",
+      "action": "<SELECT|MERGE|REJECT_ALL|APPROVE|BACKTRACK|BACKTRACK_MVP|BACKTRACK_DIR|REVISE|FORCE_OVERRIDE>",
       "detail": "",
       "timestamp": "<ISO 8601>"
     }

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -157,6 +157,30 @@ Read spec_review.json results. Check **three conditions**:
   - User actions: `APPROVED` → emit `APPROVED`, `CHANGES_REQUESTED` → emit `CHANGES_REQUESTED` → return to Phase 1
 
 After approval (or auto-continue):
+
+### Phase 5: Decision Ledger
+
+Append this stage's auto_decisions to `specs/decisions.json` (create if not exists). This file is the unified decision audit trail across all stages.
+
+```json
+{
+  "decisions": [
+    {
+      "stage": "spec",
+      "timestamp": "<ISO 8601>",
+      "decision": "",
+      "alternatives": [],
+      "rationale": "",
+      "impact": "",
+      "impact_level": "low | medium | high"
+    }
+  ],
+  "contract_amendments": []
+}
+```
+
+If the file already exists (e.g., from a previous /discover run), **append** to the `decisions` array — do not overwrite.
+
 "spec artifacts written to specs/. Run /build to continue."
 
 ## Lite Mode Behavior

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -13,6 +13,8 @@ You are performing constrained design expansion. Module decomposition, interface
 
 ## Input
 
+Verify that `specs/discover.json` exists. If missing, inform the user: "Run /discover first to generate specs/discover.json." and halt.
+
 Read `specs/discover.json`. Check `discover.json.mode` to determine full or lite behavior.
 If `specs/build_report.json` exists (backtrack from /build), read it too for diagnostic context.
 

--- a/README_AGENT.md
+++ b/README_AGENT.md
@@ -68,7 +68,7 @@ Each command is defined in `.claude/commands/<name>.md`. Read the command file f
 - State machines for all three stages (states, events, guards)
 - Backtrack triggers and safety limits (`max_backtrack_count: 3`, cycle detection)
 - Enhancement guardrail toggles (`tracer_bullet`, `mutation_testing`, `multi_sample_6cs`)
-- Mode: `full` or `lite` (set during /discover Step 0)
+- Mode (`full` or `lite`) is determined during /discover Step 0 and stored in `discover.json.mode`
 
 ### Agents
 

--- a/README_AGENT.md
+++ b/README_AGENT.md
@@ -56,9 +56,9 @@ No dependencies. No build step. No config beyond the above.
 
 | Command | Reads | Writes |
 |---------|-------|--------|
-| `/discover` | `workflow.json` | `specs/discover.json`, `specs/discover_history.json` |
+| `/discover` | (user input only) | `specs/discover.json`, `specs/discover_history.json`, `specs/discover_review.json` |
 | `/spec` | `specs/discover.json` | `specs/spec.json`, `specs/spec_review.json` |
-| `/build` | `specs/spec.json`, `specs/discover.json` | `specs/tests.json`, `specs/build_report.json` |
+| `/build` | `specs/spec.json`, `specs/discover.json` | `specs/tests.json`, `specs/build_report.json`, `specs/build_review.json` |
 
 Each command is defined in `.claude/commands/<name>.md`. Read the command file for full behavior.
 
@@ -77,11 +77,14 @@ Two sub-agents spawned by commands. Both **core guardrails** (cannot be disabled
 | Agent | Prompt | Role | Spawned By |
 |-------|--------|------|------------|
 | Supervisor | `.claude/commands/supervisor.md` | Global coherence (forest) | /discover, /spec, /build |
-| Critic | `.claude/commands/critic.md` | Backward verification (trees) | /discover, /spec, /build |
+| Critic | `.claude/commands/critic.md` | Independent quality verification (trees) | /discover, /spec, /build |
 
 **Supervisor input:** `discover.json` anchor (`constraints` + `selected_direction` + `tech_direction`) + current stage output.
 
-**Critic input:** Contract artifacts only. Independent session (no conversation history).
+**Critic input per phase:**
+- `/discover`: `discover.json` only → 6Cs quality audit, invariant verification, acceptance criteria testability, coverage check → writes `discover_review.json`
+- `/spec`: `discover.json` + `spec.json` → backward verification, undeclared behavior check → writes `spec_review.json`
+- `/build`: `build_report.json` (acceptance_result) + `discover.json` (core_scenarios) + actual code → independent scenario walkthrough vs AI acceptance → writes `build_review.json`
 
 ### ID Naming
 

--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,7 @@ install_project() {
   mkdir -p "${target_dir}/.claude/commands"
   mkdir -p "${target_dir}/specs"
 
-  # Copy commands (skip if global commands exist and are identical)
+  # Copy commands
   for cmd in discover.md spec.md build.md supervisor.md critic.md; do
     cp "${SCRIPT_DIR}/.claude/commands/${cmd}" "${target_dir}/.claude/commands/${cmd}"
   done

--- a/workflow.json
+++ b/workflow.json
@@ -1,13 +1,12 @@
 {
   "name": "nopilot",
   "version": "3.0",
-  "mode": "full",
   "max_backtrack_count": 3,
   "backtrack_cycle_detection": true,
   "agents": {
     "supervisor": {
       "trigger": "stage_complete",
-      "input": ["discover.json#constraints", "discover.json#selected_direction", "current_stage_output"],
+      "input": ["discover.json#constraints", "discover.json#selected_direction", "discover.json#tech_direction", "current_stage_output"],
       "output_field": "global_coherence_check",
       "classification": "core_guardrail",
       "on_drift": "pause_notify_user"
@@ -38,7 +37,12 @@
         "tech_stack", "time", "platform", "exclusions", "budget", "existing_assets"
       ],
       "states": {
-        "initial": "direction",
+        "initial": "constraints",
+        "constraints": {
+          "on": {
+            "MODE_SELECTED": "direction"
+          }
+        },
         "direction": {
           "on": {
             "SELECT": "mvp",

--- a/workflow.json
+++ b/workflow.json
@@ -31,7 +31,7 @@
       "description": "Requirement space exploration and convergence",
       "context_dependencies": [],
       "backtrack_context": ["specs/discover_history.json"],
-      "outputs": ["specs/discover.json", "specs/discover_history.json"],
+      "outputs": ["specs/discover.json", "specs/discover_history.json", "specs/discover_review.json"],
       "checkpoint": "required",
       "constraint_dimensions": [
         "tech_stack", "time", "platform", "exclusions", "budget", "existing_assets"
@@ -145,7 +145,7 @@
       "description": "TDD implementation per spec with tracer bullet and auto-acceptance",
       "context_dependencies": ["specs/spec.json", "specs/discover.json"],
       "backtrack_context": [],
-      "outputs": ["specs/tests.json", "specs/build_report.json"],
+      "outputs": ["specs/tests.json", "specs/build_report.json", "specs/build_review.json"],
       "test_review_checkpoint": "optional",
       "max_retries_per_module": 3,
       "states": {


### PR DESCRIPTION
## Summary

- **[CRITICAL]** Critic agent 新增 `/discover` 和 `/build` 两个阶段的完整审查协议，每个阶段定义了输入、检查内容、输出 schema、问题处理行为，全局自修复上限 2 次迭代
- **[HIGH x5]** 修复 workflow.json Supervisor input 缺失、discover 状态机缺少 Step 0、build.md Step 7 执行顺序悖论、README_AGENT.md 文档不一致、mode 双源存储问题
- **[MEDIUM x3]** 补充 decision_log action 枚举、添加上游 artifact 预检、修正 install.sh 误导注释

## Changed Files (7)

| File | Change |
|------|--------|
| `.claude/commands/critic.md` | Complete rewrite — add `/discover` (6Cs audit, invariant verification, AC testability, coverage) and `/build` (independent scenario walkthrough vs AI acceptance) review protocols |
| `.claude/commands/build.md` | Fix Step 7 ordering; update Critic invocation to match new protocol; add artifact pre-flight check |
| `.claude/commands/spec.md` | Add upstream artifact existence check |
| `.claude/commands/discover.md` | Add `BACKTRACK` to decision_log action enum |
| `workflow.json` | Add `tech_direction` to Supervisor input; add `constraints` initial state; remove stale `mode` field |
| `README_AGENT.md` | Fix `/discover` reads column; update Critic description with per-phase details; add new review artifacts to writes columns |
| `install.sh` | Remove misleading "skip if identical" comment |

## Test plan

- [ ] Verify `workflow.json` is valid JSON
- [ ] Verify `install.sh` passes `bash -n` syntax check
- [ ] Review Critic `/discover` protocol matches discover.md's Critic Integration section expectations
- [ ] Review Critic `/build` protocol matches build.md's Step 6 Critic Verification expectations
- [ ] Confirm no cross-file references are broken (Supervisor input, Critic output filenames, artifact schemas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)