### PR TITLE
fix: worktree 创建后 symlink node_modules (#37)

### DIFF
--- a/src/lash/worktree-manager.ts
+++ b/src/lash/worktree-manager.ts
@@ -5,6 +5,7 @@
 import { execFile } from 'node:child_process';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { existsSync, symlinkSync } from 'node:fs';
 import type { MergeResult, WorktreeInfo, PreserveResult, UnexpectedFilesResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -92,6 +93,13 @@ export async function createWorktree(moduleId: string, projectRoot: string = '.'
       throw new Error(`worktree_exists: worktree for ${moduleId} already exists`);
     }
     throw new Error(`git_error: ${stderr}`);
+  }
+
+  // Symlink node_modules from main repo — worktrees lack it (gitignored). (#37)
+  const srcModules = join(projectRoot, 'node_modules');
+  const destModules = join(path, 'node_modules');
+  if (existsSync(srcModules) && !existsSync(destModules)) {
+    symlinkSync(srcModules, destModules, 'dir');
   }
 
   return { worktree_path: path, branch_name: branch };
@@ -211,6 +219,13 @@ export async function createConflictResolutionWorktree(
   const result = await runGit(['worktree', 'add', '-b', branch, path, headSha], projectRoot);
   if (result.returncode !== 0) {
     throw new Error(`git_error: ${result.stderr.trim()}`);
+  }
+
+  // Symlink node_modules from main repo (#37)
+  const srcModules = join(projectRoot, 'node_modules');
+  const destModules = join(path, 'node_modules');
+  if (existsSync(srcModules) && !existsSync(destModules)) {
+    symlinkSync(srcModules, destModules, 'dir');
   }
 
   return { worktree_path: path, branch_name: branch };


### PR DESCRIPTION
## Summary

- `createWorktree()` 和 `createConflictResolutionWorktree()` 创建后自动 symlink 主仓库的 `node_modules`
- 解决 worktree 中 Worker 无法构建/测试的问题（`node_modules` 被 gitignore）
- 替代 main 上的 `npm install` 方案，symlink 零开销、多 Worker 并行友好

Closes #37