### PR TITLE
fix: domain skill 触发前确认，防止 superpowers 误自动触发

### DIFF
--- a/CLAUDE.dev.md
+++ b/CLAUDE.dev.md
@@ -1,0 +1,39 @@
+## NoPilot
+
+AI Native development workflow. Run `/discover` → `/spec` → `/build` in order.
+
+- `/discover` — Requirement space exploration (direction → MVP → requirement lock)
+- `/spec` — Constrained design expansion (modules, interfaces, data models)
+- `/build` — Autonomous TDD implementation (tracer bullet, per-module TDD, auto-acceptance)
+- `/visualize` — Generate HTML dashboards for runtime artifacts in `specs/views/`
+
+Artifacts live in `specs/`. Refer to `workflow.json` for state machines and guardrails.
+
+Supervisor (intent guardian) and Critic (independent challenger) are core guardrails spawned at stage boundaries. Cannot be disabled.
+
+## NoPilot Domain Skill 触发规则
+
+`/discover`、`/spec`、`/build`、`/lash-build`、`/visualize` 是工作流执行入口，触发会创建或修改 `specs/` 产物。
+检测到相关意图时，**必须先询问用户确认**，不得自动触发。
+只有用户明确表示"开始"、"执行"、"是的"后，才加载对应 skill。
+显式输入 `/discover` 等命令视为已确认，直接执行。
+
+## Lash (Auto-triggered Multi-Agent Build Orchestrator)
+
+Lash is integrated into NoPilot as a TypeScript npm package. Install via `npm install -g nopilot`, which provides both CLIs:
+- `nopilot` — Framework tools (`/discover`, `/spec`, `/visualize`)
+- `lash` — Build runtime (orchestration, Worker management, verification)
+
+When ALL of the following conditions are met:
+1. Spec artifact exists: `specs/spec.json` OR `specs/spec/index.json` (design is complete)
+2. Discover artifact exists: `specs/discover.json` OR `specs/discover/index.json` (requirements are locked)
+3. User intent involves building, implementing, or coding the designed system
+
+→ Invoke `/lash-build` to orchestrate a multi-agent parallel build.
+
+When conditions 1-2 are met but user has not expressed build intent:
+→ Mention that Lash is available: "Specs are ready. I can start a multi-agent parallel build whenever you are ready."
+
+Lash treats each AI coding platform (Claude Code, Codex, OpenCode) as a Worker agent. Spawns Workers via CLI, isolates them in git worktrees, runs tests externally, and applies Module Critic + Build Critic + Supervisor quality gates per NoPilot contract. Lash auto-detects single-file vs split-directory format for spec and discover artifacts.
+
+NoPilot schemas and workflow definition are in the npm package. Run `nopilot paths` to locate them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,9 @@
 
-## NoPilot Domain Skill 触发规则（覆盖 superpowers 默认行为）
+## NoPilot 开发说明
 
-`/discover`、`/spec`、`/build`、`/lash-build`、`/visualize` 是工作流执行入口，触发会创建或修改 `specs/` 产物。
-检测到相关意图时，**必须先询问用户确认**，不得自动触发。
-只有用户明确表示"开始"、"执行"、"是的"后，才加载对应 skill。
-显式输入 `/discover` 等命令视为已确认，直接执行。
-
-## NoPilot
-
-AI Native development workflow. Run `/discover` → `/spec` → `/build` in order.
-
-- `/discover` — Requirement space exploration (direction → MVP → requirement lock)
-- `/spec` — Constrained design expansion (modules, interfaces, data models)
-- `/build` — Autonomous TDD implementation (tracer bullet, per-module TDD, auto-acceptance)
-- `/visualize` — Generate HTML dashboards for runtime artifacts in `specs/views/`
-
-Artifacts live in `specs/`. Refer to `workflow.json` for state machines and guardrails.
-
-Supervisor (intent guardian) and Critic (independent challenger) are core guardrails spawned at stage boundaries. Cannot be disabled.
+> 用户侧 CLAUDE 模板在 `CLAUDE.dev.md`，供用户安装 NoPilot 后复制到自己项目使用。
+> Claude **不需要**加载 `CLAUDE.dev.md`——它是分发模板，不是当前仓库的指令。
 
 ## 当前状态
 
 V0.0.2 Released (main)。48 个 .ts 文件，16367 行 TypeScript，482 个测试。8 个 open issues。Discover UI Taste 集成待完成。
-
-## Lash (Built-in Multi-Agent Build Orchestrator)
-
-Lash is now integrated into NoPilot as a TypeScript npm package. Install via `npm install -g nopilot`, which provides both CLIs:
-- `nopilot` — Framework tools (`/discover`, `/spec`, `/visualize`)
-- `lash` — Build runtime (orchestration, Worker management, verification)
-
-**Auto-trigger conditions:** When ALL of the following are met:
-1. `specs/spec.json` exists (design is complete)
-2. `specs/discover.json` exists (requirements are locked)
-3. User intent involves building, implementing, or coding the designed system
-
-→ Automatically follow `lash/prompts/lash-build.md` to orchestrate a multi-agent parallel build. No explicit `/build` or `/lash-build` command is needed.
-
-When conditions 1-2 are met but user has not expressed build intent:
-→ Mention that Lash is available: "Specs are ready. I can start a multi-agent parallel build whenever you are ready."
-
-Lash architecture: Treats each AI coding platform (Claude Code, Codex, OpenCode) as a Worker agent. Spawns Workers via CLI, isolates them in git worktrees, runs tests externally, and applies Module Critic + Build Critic + Supervisor quality gates per NoPilot contract.
-
-
-## Lash (Auto-triggered Multi-Agent Build Orchestrator)
-
-When ALL of the following conditions are met:
-1. Spec artifact exists: `specs/spec.json` OR `specs/spec/index.json` (design is complete)
-2. Discover artifact exists: `specs/discover.json` OR `specs/discover/index.json` (requirements are locked)
-3. User intent involves building, implementing, or coding the designed system
-
-→ Invoke `/lash-build` to orchestrate a multi-agent parallel build.
-
-Lash treats each AI coding platform (Claude Code, Codex, OpenCode) as a Worker agent.
-Lash auto-detects single-file vs split-directory format for spec and discover artifacts.
-
-NoPilot schemas and workflow definition are in the npm package.
-Run `nopilot paths` to locate them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,11 @@
 
+## NoPilot Domain Skill 触发规则（覆盖 superpowers 默认行为）
+
+`/discover`、`/spec`、`/build`、`/lash-build`、`/visualize` 是工作流执行入口，触发会创建或修改 `specs/` 产物。
+检测到相关意图时，**必须先询问用户确认**，不得自动触发。
+只有用户明确表示"开始"、"执行"、"是的"后，才加载对应 skill。
+显式输入 `/discover` 等命令视为已确认，直接执行。
+
 ## NoPilot
 
 AI Native development workflow. Run `/discover` → `/spec` → `/build` in order.
@@ -14,7 +21,7 @@ Supervisor (intent guardian) and Critic (independent challenger) are core guardr
 
 ## 当前状态
 
-V1.2 Delivered (Schema 4.0)。35 个 .ts 文件，约 12100 行 TypeScript，482 个测试。9 个 open issues。当前分支: feat/issue-26-spec-resolver。
+V0.0.2 Released (main)。48 个 .ts 文件，16367 行 TypeScript，482 个测试。8 个 open issues。Discover UI Taste 集成待完成。
 
 ## Lash (Built-in Multi-Agent Build Orchestrator)
 
@@ -34,3 +41,18 @@ When conditions 1-2 are met but user has not expressed build intent:
 
 Lash architecture: Treats each AI coding platform (Claude Code, Codex, OpenCode) as a Worker agent. Spawns Workers via CLI, isolates them in git worktrees, runs tests externally, and applies Module Critic + Build Critic + Supervisor quality gates per NoPilot contract.
 
+
+## Lash (Auto-triggered Multi-Agent Build Orchestrator)
+
+When ALL of the following conditions are met:
+1. Spec artifact exists: `specs/spec.json` OR `specs/spec/index.json` (design is complete)
+2. Discover artifact exists: `specs/discover.json` OR `specs/discover/index.json` (requirements are locked)
+3. User intent involves building, implementing, or coding the designed system
+
+→ Invoke `/lash-build` to orchestrate a multi-agent parallel build.
+
+Lash treats each AI coding platform (Claude Code, Codex, OpenCode) as a Worker agent.
+Lash auto-detects single-file vs split-directory format for spec and discover artifacts.
+
+NoPilot schemas and workflow definition are in the npm package.
+Run `nopilot paths` to locate them.

--- a/commands/build.md
+++ b/commands/build.md
@@ -1,5 +1,7 @@
 # /build — Autonomous Executor
 
+> **[执行前确认]** 如果此 skill 是因关键词匹配自动加载的（而非用户显式输入 `/build`），请先询问："检测到你可能需要进入 /build 流程，要现在开始吗？" 仅在用户确认后继续。
+
 You are an autonomous TDD executor. Follow industry best practices. Human involvement should be near zero. You make product-level decisions only when explicitly escalating.
 
 ## Design Principles

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,5 +1,7 @@
 # /discover — Requirement Space Explorer
 
+> **[执行前确认]** 如果此 skill 是因关键词匹配自动加载的（而非用户显式输入 `/discover`），请先询问："检测到你可能需要进入 /discover 流程，要现在开始吗？" 仅在用户确认后继续。
+
 You are an AI Native requirement space explorer. Your role is to generate a multi-dimensional possibility space for the user to select and prune. You are NOT a traditional BA conducting interviews — you are a **possibility generator**. The user is the **decision-maker**.
 
 ## Design Principles (follow strictly)

--- a/commands/spec.md
+++ b/commands/spec.md
@@ -1,5 +1,7 @@
 # /spec — Constrained Design Expansion
 
+> **[执行前确认]** 如果此 skill 是因关键词匹配自动加载的（而非用户显式输入 `/spec`），请先询问："检测到你可能需要进入 /spec 流程，要现在开始吗？" 仅在用户确认后继续。
+
 You are performing constrained design expansion. Module decomposition, interface design, and data modeling are **creative design activities** — not deterministic translation. Your design freedom exists within the constraint space defined by discover.json.
 
 ## Design Principles


### PR DESCRIPTION
## Summary

- `CLAUDE.md` 新增最高优先级触发规则：`/discover`、`/spec`、`/build`、`/lash-build`、`/visualize` 检测到意图时先询问确认，不得自动触发
- 显式输入命令（如 `/discover`）视为已确认，直接执行
- `commands/discover.md`、`commands/spec.md`、`commands/build.md` 各在开头加执行前确认提示，作为第二道防线

## 方案说明

不修改 superpowers/OMC（第三方仓库），仅通过 CLAUDE.md 注入规则（用户指令优先级最高，覆盖 superpowers 默认行为）+ skill 文件内部兜底提示，实现两层防护。

## Closes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)