### PR TITLE
feat: optimize discover skill context for 256K models

### DIFF
--- a/commands/discover/SKILL.md
+++ b/commands/discover/SKILL.md
@@ -5,52 +5,66 @@
 
 > **[执行前确认]** 如果此 skill 是因关键词匹配自动加载的（而非用户显式输入 `/discover`），请先询问："检测到你可能需要进入 /discover 流程，要现在开始吗？" 仅在用户确认后继续。
 
-You are an AI Native requirement space explorer. Your role is to generate a multi-dimensional possibility space for the user to select and prune. You are NOT a traditional BA conducting interviews — you are a **possibility generator**. The user is the **decision-maker**.
+> **[Dedup Guard]** If this skill has already been injected, do NOT re-inject. Command arguments appear in the user's message — do NOT append them to this skill text.
+
+> **[Context Budget]** Load dispatch protocol once at start:
+> ```
+> Use the Skill tool to load: commands/discover/dispatch-protocol.md
+> ```
+
+You are a possibility generator. The user is the decision-maker.
 
 ## Design Principles (follow strictly)
 
 1. Present technical decisions in **product-impact language**, not jargon
-2. **Challenge** all requirements equally (user-stated and AI-inferred) by surfacing costs and risks
-3. All dimensions (requirements, feasibility, competitive risks, effort) appear **simultaneously** in each output
-4. You are evaluating from **first principles**, not applying templates
+2. **Challenge** all requirements equally by surfacing costs and risks
+3. All dimensions (requirements, feasibility, competitive risks, effort) appear **simultaneously**
+4. Evaluate from **first principles**, not templates
 
 ---
 
 ## Mode Detection Block (runs before Step 0a)
 
+<!-- DISPATCH CONTRACT
+  task: "Detect project mode (greenfield vs feature)"
+  input: ["project root path"]
+  instructions: "commands/discover/mode-detection.md"
+  output_file: specs/discover/mode-result.json
+  output_summary: mode + rationale + profile_stale (max 20 items, <= 500 chars)
+  on_error: standard
+-->
+
+Dispatch subagent → `commands/discover/mode-detection.md`. Present mode verdict to user:
+- `greenfield`: proceed to Step 0a
+- `feature` + profile: "Greenfield or feature mode?" (add stale warning if applicable)
+- `feature` + no profile: "Existing codebase detected. Greenfield or feature?"
+
+After user confirms: `greenfield` → Step 0a | `mode=feature` → load:
 ```
-Use the Skill tool to load: commands/discover/mode-detection.md
+Use the Skill tool to load: commands/discover/idea-intake.md (Feature Mode Steps 0a-0d)
 ```
+
+**Error handling**: If subagent fails, follow dispatch-protocol.md (retry or fallback).
 
 ---
 
 ## Step 0 — Greenfield Idea & Constraint Collection (mode=greenfield only)
 
-**If `mode=feature`**: Skip this section. Sub-skill `idea-intake.md` handles Feature Steps 0a-0d above.
+**If `mode=feature`**: Skip. Sub-skill `idea-intake.md` handles Feature Steps 0a-0d.
 
 ### Step 0a — Idea Collection
+> "What's your idea? It can be a single sentence, a paragraph, or even a vague feeling."
 
-> "What's your idea? It can be a single sentence, a paragraph, a keyword, or even a vague feeling — anything works."
-
-Accept any form of input. If too vague, ask ONE follow-up: "Can you tell me a bit more about what problem you're trying to solve, or who this is for?"
+If too vague, ask ONE follow-up about the problem or target users.
 
 ### Step 0b — Idea Structuring
-
-Organize into:
-- **Problem statement**, **Target users**, **Core value proposition**, **Initial scope impression**
-
-Present and ask: "Here's how I understand your idea — is this accurate? Anything to add or correct?" Wait for confirmation.
+Organize into: **Problem statement**, **Target users**, **Core value proposition**, **Scope impression**. Present and confirm.
 
 ### Step 0c — Targeted Constraint Collection
-
-Ask only constraints relevant to this idea (max 2-3 per round):
-- Tech stack limitations, Time constraints, Target platform, Explicit exclusions, Budget/resource constraints, Existing assets
-
-For any constraint not asked, record as `null`.
+Ask max 2-3 per round: Tech stack, Time, Platform, Exclusions, Budget, Existing assets. Record unasked as `null`.
 
 ### Step 0d — Mode Recommendation
-
-Recommend `full` or `lite` mode. Wait for confirmation before proceeding to Layer 1.
+Recommend `full` or `lite` mode. Wait for confirmation.
 
 ---
 
@@ -58,124 +72,108 @@ Recommend `full` or `lite` mode. Wait for confirmation before proceeding to Laye
 
 ### Layer 1 — Direction Selection
 
-**If `mode=feature`**: Skip Layer 1. Write `selected_direction: { description: "extend existing project", differentiator: "n/a", rationale: "feature mode — direction inherited from existing codebase", pre_mortem: [], grounding: "ai_judgment_only" }` and proceed to Layer 2.
+**If `mode=feature`**: Skip Layer 1. Write `selected_direction: { description: "extend existing project", differentiator: "n/a", rationale: "feature mode", pre_mortem: [], grounding: "ai_judgment_only" }` → Layer 2.
 
-**If `mode=greenfield`**: Run Layer 1 as follows:
+<!-- DISPATCH CONTRACT
+  task: "Competitive research + generate 3-5 product directions"
+  input: ["specs/discover/index.json"]
+  instructions: "Search competitive landscape. Generate directions with: description, differentiator, biggest risk, grounding."
+  output_file: specs/discover/directions-draft.json
+  output_summary: direction summaries (max 20 items, <= 3K chars)
+  on_error: standard
+-->
 
-**Full Mode:**
-1. Search competitive landscape for similar products and market positioning.
-2. Generate **3-5 product directions**, each containing:
-   - **Description:** What this product does and for whom
-   - **Differentiator:** What makes this direction distinct from existing solutions
-   - **Biggest risk:** The single most likely reason this direction fails
-3. All directions must satisfy the constraints collected in Step 0.
-4. If search fails or returns insufficient data, mark `grounding: "ai_judgment_only"` on affected directions.
+**Full Mode:** Dispatch subagent for competitive research. Before dispatch, write Step 0 results to artifact. Present returned direction summaries to user.
+**Lite Mode:** Recommend single direction inline (no subagent needed).
 
-**Lite Mode:** Recommend a single direction with clear rationale. State why it best fits the constraints.
+**User Actions**: SELECT `<index>` / MERGE `<indices>` + `<note>` / REJECT_ALL `<reason>` (re-dispatch)
 
-**User Actions** (parse natural language):
-- **SELECT `<index>`**: Choose direction by number
-- **MERGE `<indices>` + `<note>`**: Combine elements from multiple directions
-- **REJECT_ALL `<reason>`**: All directions miss the mark — acknowledge, incorporate reason, regenerate
-
-After user action, load completeness sub-skill:
-```
-Use the Skill tool to load: commands/discover/completeness.md (Layer 1 assessment)
-```
+After user action: `Use the Skill tool to load: commands/discover/completeness.md (Layer 1 assessment)`
 
 ### Layer 2 — MVP Definition + Technical Path
 
-**If `mode=feature`**: Load feature-specific intake:
-```
-Use the Skill tool to load: commands/discover/idea-intake.md (Feature Mode Layer 2)
-```
+**If `mode=feature`**: `Use the Skill tool to load: commands/discover/idea-intake.md (Feature Mode Layer 2)`
+**If `mode=greenfield`**: Run full Layer 2. After APPROVE: `Use the Skill tool to load: commands/discover/completeness.md (Layer 2 assessment)`
 
-**If `mode=greenfield`**: Run full Layer 2. After user APPROVE, load:
-```
-Use the Skill tool to load: commands/discover/completeness.md (Layer 2 assessment)
-```
+After Layer 2 approved + philosophy confirmed → check for UI. Dispatch subagent for Skill: ui-taste exploration:
 
-After Layer 2 approved and philosophy confirmed → check for UI:
+<!-- DISPATCH CONTRACT
+  task: "Generate UI mockups via Stitch MCP or fallback"
+  input: ["specs/discover/index.json"]
+  instructions: "commands/discover/ui-taste.md"
+  output_file: specs/mockups/index.html
+  output_summary: screen id + page + description + tier (max 20 items, <= 2K chars per batch)
+  on_error: standard
+-->
 
-```
-Use the Skill tool to load: commands/discover/ui-taste.md
-```
+Present screen summaries. User feedback loop:
+- **Direct select** → write `ui_taste` to artifact → Layer 3
+- **Text feedback** → re-dispatch with iteration instructions
+- **Hybrid DNA** → re-dispatch with synthesis instructions
+- **No UI** (CLI/API/backend) → record `"ui_taste": null` → Layer 3
 
-**Error handling for any sub-skill load failure**: Stop, report missing file path, instruct user to run `nopilot doctor`.
+**Error handling**: Stop, report missing file path, instruct `nopilot doctor`.
 
 ### Layer 3 — Requirement Lock
 
-**If `mode=feature`**: After generating EARS acceptance criteria for each requirement, auto-generate `regression_guard` EARS criteria for any requirement touching an existing module from profile L1 `modules[]`. Format: `THE SYSTEM SHALL continue to [specific existing behavior] when [the new feature change is applied]`. Set `type: "regression_guard"`, `source: "ai_inferred"`.
+<!-- DISPATCH CONTRACT
+  task: "Generate Layer 3 requirement lock table"
+  input: ["specs/discover/"]
+  instructions: "EARS acceptance criteria, invariants, quality checks, challenge protocol per SKILL.md Layer 3 spec."
+  output_file: specs/discover/requirements.json
+  output_summary: req count + invariant count + high risk items + conflicts (max 20 items, <= 3K chars)
+  on_error: standard
+-->
 
-**If `mode=greenfield`**: Regression guards may still be generated for requirements that reference system invariants.
+Before dispatch, write all Layer 2 decisions to artifact (INV-003). Dispatch subagent → returns requirement summary. Present challenge items (ACCEPT_COST / SIMPLIFY / DEFER_V2).
 
-**Input:** Confirmed MVP + tech direction + core scenarios + design philosophy from Layer 2.
+**If `mode=feature`**: subagent auto-generates `regression_guard` EARS for existing modules.
+**If `mode=greenfield`**: regression guards for system invariants.
 
-For each requirement, generate simultaneously:
-- **User Story**: `As a [role], I want [feature], so that [benefit]`
-- **EARS Acceptance Criteria**: event_driven / condition / state / regression_guard types, each with `id`, `type`, `source_refs`
-- **Source Annotation**: `user_stated` or `ai_inferred`
-- **Downstream Impact**: tech implications, test complexity (Low/Medium/High), effort estimate
+**User Actions**: APPROVE / REVISE `<req_ids>` (re-dispatch) / FORCE_OVERRIDE / BACKTRACK_MVP / BACKTRACK_DIR
 
-Also generate **System Invariants**: `id`, `statement`, `scope`, `requirement_refs`.
+After APPROVE: `Use the Skill tool to load: commands/discover/completeness.md (Layer 3 — all dims >= 70%)`
 
-**Quality Checks (inline):**
-- Inter-requirement conflict detection — flag contradictions, must resolve before APPROVE
-- Coverage check — verify core scenarios from Layer 2 are fully covered
-- Correctness Challenge Protocol — challenge high-cost/high-risk requirements: ACCEPT_COST / SIMPLIFY / DEFER_V2. Low-cost items: `pass_confirmed`.
+After Layer 3 approved → Artifact Generation:
 
-**NOTE:** 6Cs quality assessment is NOT performed inline — handled by Critic agent only.
+<!-- DISPATCH CONTRACT
+  task: "Finalize and write discover artifacts"
+  input: ["specs/discover/"]
+  instructions: "commands/discover/artifact-writer.md"
+  output_file: specs/discover/index.json
+  output_summary: written file list + format (max 20 items, <= 500 chars)
+  on_error: standard
+-->
 
-**Lite Mode:** Basic acceptance criteria, invariants optional, challenge limited to high-cost items only.
-
-**User Actions**: APPROVE / REVISE `<req_ids>` + `<changes>` / FORCE_OVERRIDE `<issues>` / BACKTRACK_MVP / BACKTRACK_DIR
-
-**APPROVE Guard:** Only valid when no unresolved conflicts, all invariants extracted, all core scenarios covered, challenge completed for all high-cost items.
-
-After user APPROVE, load completeness sub-skill:
-```
-Use the Skill tool to load: commands/discover/completeness.md (Layer 3 assessment — all dims >= 70%)
-```
-
-After Layer 3 approved → proceed to Artifact Generation:
-```
-Use the Skill tool to load: commands/discover/artifact-writer.md
-```
+Dispatch subagent → `commands/discover/artifact-writer.md`. Present confirmation.
 
 ### Critic + Supervisor Dispatch
-
-After artifacts written:
 
 <!-- DISPATCH CONTRACT
   agent: critic + supervisor (sonnet, sequential)
   input_files: [specs/discover.json OR specs/discover/index.json]
   output_file: specs/discover_review.json
-  output_summary: { passed: bool, block_count: number, warn_count: number, drift_detected: bool, aligned: bool } (max 20 logical entries)
-  on_error: pause and present findings to user; wait for resolution before proceeding
+  output_summary: { passed, block_count, warn_count, drift_detected, aligned } (max 20 logical entries)
+  on_error: pause and present findings to user; wait for resolution
 -->
 ```
 Use the Skill tool to load: commands/discover/critic-supervisor.md
 ```
 
-**Error handling for critic-supervisor.md**: If file missing, stop and output missing file path + `nopilot doctor` instruction.
+**Error handling**: If file missing, output path + `nopilot doctor` instruction.
 
 ---
 
 ## ID Naming Conventions
 
-- Requirements: `REQ-001`, `REQ-002`, ... `REQ-NNN`
-- Acceptance criteria: `REQ-001-AC-1`, `REQ-001-AC-2`, ...
-- Invariants: `INV-001`, `INV-002`, ...
-- Core scenarios: `SCENARIO-001`, `SCENARIO-002`, ...
+REQ-001..NNN | REQ-001-AC-1..N | INV-001..NNN | SCENARIO-001..NNN
 
 ---
 
 ## Backtrack Handling
 
-When user wants to go back to a previous layer:
-
-1. Parse intent into: BACKTRACK_MVP (return to Layer 2) or BACKTRACK_DIR (return to Layer 1)
-2. Confirm: "Going back to [Layer X]. Your previous choices are preserved in history."
-3. Read history artifact and reference prior decisions explicitly
-4. Regenerate the layer incorporating lessons from the abandoned path
-5. Add a decision_log entry with action BACKTRACK_MVP or BACKTRACK_DIR
+1. Parse intent: BACKTRACK_MVP (→ Layer 2) or BACKTRACK_DIR (→ Layer 1)
+2. Confirm: "Going back to [Layer X]. Previous choices preserved."
+3. Read history artifact, reference prior decisions
+4. Regenerate incorporating lessons from abandoned path
+5. Add decision_log entry

--- a/commands/discover/artifact-writer.md
+++ b/commands/discover/artifact-writer.md
@@ -1,6 +1,9 @@
 <!-- nopilot-managed v<%=VERSION%> -->
+<!-- DISPATCH CONTRACT target: dispatched by SKILL.md; output <= 500 chars, max 20 items -->
 
-# discover/artifact-writer — Artifact Generation
+# discover/artifact-writer — Artifact Generation (dispatch target)
+
+You are a subagent. Your job: read the current discover artifact state and finalize all JSON files. Do NOT interact with the user directly. Return a brief confirmation summary to the main agent.
 
 ### Feature Mode: Artifact Output Path
 
@@ -195,8 +198,13 @@ The JSON schemas below are shown in single-file form; in split mode, move the co
 
 ---
 
-### Completion Output
+### Subagent Output Format (return this to main agent)
 
-After writing the discover artifacts, output:
+After writing all files, return ONLY this summary:
 
-> "discover artifacts written to specs/. Generate visualization by running: open specs/views/discover.html (or run /visualize for full dashboard). Run /spec to continue, or review the discover artifact entry point (`specs/discover.json` or `specs/discover/index.json`) first."
+```
+written: [list of file paths written]
+format: single | split
+```
+
+Keep total output under 500 chars. The main agent will present the completion message to the user.

--- a/commands/discover/dispatch-protocol.md
+++ b/commands/discover/dispatch-protocol.md
@@ -1,0 +1,69 @@
+<!-- nopilot-managed v<%=VERSION%> -->
+<!-- Feature Mode: This protocol applies equally to mode=greenfield and mode=feature discovers. No mode-specific behavior. -->
+<!-- This file defines the dispatch protocol itself — no dispatch needed to load it. -->
+
+# discover/dispatch-protocol — Subagent Dispatch Standard
+
+## Context Budget (design-time targets, verified by testing)
+
+Total main-agent context for a complete discover run: **< 200K chars** (user+assistant messages, excluding system prompts and tool schemas).
+
+Per-stage subagent summary size limits:
+- Mode Detection: < 1K chars
+- Layer 1 Research: < 3K chars
+- Layer 3 Generation: < 3K chars
+- Artifact Writing: < 500 chars
+- UI Taste (per batch): < 2K chars
+
+## Dispatch Contract Format
+
+Every subagent dispatch is declared as an HTML comment block in the skill markdown:
+
+```
+<!-- DISPATCH CONTRACT
+  task: "{what the subagent does}"
+  input: ["{file paths or directories the subagent reads}"]
+  instructions: "{sub-skill file path, or inline instructions}"
+  output_file: specs/{target-artifact-path}
+  output_summary: {structured format} (max 20 items, <= {N}K chars)
+  on_error: standard
+-->
+```
+
+## Platform Invocation
+
+Dispatch contracts are platform-agnostic. Each platform's AI agent interprets them using its native subagent mechanism:
+
+| Platform | Mechanism | Notes |
+|----------|-----------|-------|
+| Claude Code | `Agent` tool | Spawns isolated subprocess with fresh context |
+| Codex CLI | Subagent spawn | Uses `agents.max_depth` config, TOML agent definitions |
+| OpenCode | `Task` tool | YAML-based agent config, `permission.task` rules |
+
+The subagent receives full access to the input files and can read as much context as needed. Only the summary returned to the main agent counts against the context budget.
+
+## Error Handling Protocol (on_error: standard)
+
+When a subagent dispatch fails:
+
+1. **Stop** — do not silently continue
+2. **Present error** to user with context: which stage failed, what error occurred
+3. **Ask**: "Retry or fallback to main agent execution?"
+4. **If retry**: delete any partial `output_file`, then re-dispatch
+5. **If fallback**: delete any partial `output_file`, execute the stage inline in main agent, warn user: "Running inline — context consumption will increase"
+
+### Domain Error Mapping
+
+All domain-specific errors from subagent modules map to three categories:
+
+| Category | Errors | Trigger |
+|----------|--------|---------|
+| `error` | no_read_access, empty_directory, search_failed, index_not_found, discover_dir_not_found, incomplete_layer2, write_permission_denied, skill_not_found, stitch_mcp_unavailable, stitch_api_error, mcp_not_inherited, screen_id_not_found, req_id_not_found | Subagent completes but reports failure |
+| `timeout` | Network/process hangs | Subagent does not return within platform timeout |
+| `unsupported` | Platform lacks subagent support | Dispatch mechanism not available |
+
+## Dedup Guard
+
+If the discover skill has already been injected into the conversation context (e.g., via `/discover` command auto-injection), subsequent `Skill` tool invocations for the same skill SHALL skip re-injection. The agent should check whether the skill instructions are already present before loading.
+
+Additionally, `/discover` command arguments SHALL NOT be appended to the skill text as an ARGUMENTS section. Arguments appear only in the user's original message.

--- a/commands/discover/mode-detection.md
+++ b/commands/discover/mode-detection.md
@@ -1,35 +1,27 @@
 <!-- nopilot-managed v<%=VERSION%> -->
-<!-- Feature Mode: This file defines the Mode Detection Block for /discover. Loaded by SKILL.md before Step 0a. -->
+<!-- Feature Mode: This file defines the Mode Detection Block for /discover. Executed via dispatch from SKILL.md. -->
+<!-- DISPATCH CONTRACT target: dispatched by SKILL.md; output <= 500 chars, max 20 items -->
 
-## Mode Detection Block (runs before Step 0a)
+## Mode Detection Block (dispatch target)
 
-### Feature Mode: Entry Mode Detection
+You are a subagent. Your job: detect the project mode and return a structured summary to the main agent. Do NOT interact with the user directly.
 
-Before collecting ideas, detect the current project state and set `mode` in context.
-
-**Detection logic:**
+### Detection Logic
 
 1. Check for `.nopilot/profile/` directory:
    - **Does not exist** → check for existing source code files (`.ts`, `.js`, `.py`, `.go`, `.java`, `.rs`, `.rb`, `.swift`, `.kt`, `*.html`, `*.css` under `src/`, `lib/`, `app/`, or project root)
-     - **No source code found** → `mode = greenfield` (pure_greenfield). Proceed directly to Step 0a unchanged.
-     - **Source code found** → `mode = first_time_onboarding`. Scan codebase via MOD-003 `scanCodebase`. Generate initial L0/L1/L3 profile layers. Then ask:
-       > "I detected an existing codebase. Would you like to run a full project discover (define the product from scratch, greenfield mode) or add a feature to the existing project (feature mode)?"
-       - User chooses **greenfield** → `mode = greenfield`. Continue with Step 0a unchanged.
-       - User chooses **feature** → `mode = feature`. Load sub-skill for Feature Mode intake:
-         ```
-         Use the Skill tool to load: commands/discover/idea-intake.md (Feature Mode Steps 0a-0d)
-         ```
-   - **Exists** → `mode = returning_project`. Call MOD-001 `checkStaleness` on the profile.
-     - If stale: warn the user: "Your project profile was last updated [N days ago] and may not reflect recent code changes."
-     - Ask:
-       > "Project profile found. Would you like to start a new greenfield discover (redefine the product) or add a feature to the existing project?"
-     - User chooses **greenfield** → `mode = greenfield`. Continue with Step 0a unchanged.
-     - User chooses **feature** → `mode = feature`. Load sub-skill:
-       ```
-       Use the Skill tool to load: commands/discover/idea-intake.md (Feature Mode Steps 0a-0d)
-       ```
+     - **No source code found** → `mode = greenfield`
+     - **Source code found** → `mode = feature` (first-time onboarding — main agent will ask user to confirm)
+   - **Exists** → `mode = feature` (returning project — main agent will ask user to confirm)
 
-Write `mode` (`"greenfield"` or `"feature"`) to the current conversation context.
+2. If `.nopilot/profile/` exists, check staleness: read the profile's `updated_at` timestamp and compare to current date.
 
-**Error handling:** If the sub-skill file `commands/discover/idea-intake.md` cannot be found, stop immediately and output:
-> "Missing sub-skill: `commands/discover/idea-intake.md` — expected at `<absolute path>`. Run `nopilot doctor` to repair your installation, then re-run `/discover`."
+### Output Format (return this to main agent)
+
+```
+mode: greenfield | feature
+rationale: {one-line explanation, e.g., "No source code found — pure greenfield" or "Profile exists, last updated 3 days ago"}
+profile_stale: true | false | n/a
+```
+
+Keep total output under 500 chars. Do not return file contents, code snippets, or detailed directory listings.

--- a/commands/discover/ui-taste.md
+++ b/commands/discover/ui-taste.md
@@ -1,6 +1,27 @@
 <!-- nopilot-managed v<%=VERSION%> -->
+<!-- Feature Mode: mode=feature uses creativeRange REFINE; mode=greenfield uses REIMAGINE. -->
+<!-- DISPATCH CONTRACT target: dispatched by SKILL.md; output <= 2K chars per batch, max 20 items -->
 
-# discover/ui-taste — UI Taste Exploration
+# discover/ui-taste — UI Taste Exploration (dispatch target)
+
+You are a dispatch target. Execute all UI mockup generation (Stitch MCP or fallback tiers), serve previews, and return screen summaries to the main agent. The main agent handles user feedback — you receive iteration instructions via re-dispatch.
+
+### Output Format (return this to main agent after each generation batch)
+
+```
+screens:
+  - id: "{screen_id}"
+    page: "{page_name}"
+    description: "one-line visual description of the design"
+    variant_count: {N}
+stitch_project_id: "{id or null}"
+tier: 1 | 2 | 3
+preview_url: "{local url or null}"
+```
+
+Keep total output under 2K chars per batch. Do NOT return raw Stitch JSON, component trees, or full HTML content. The main agent only needs IDs and descriptions to present choices to the user.
+
+---
 
 ### Feature Mode: UI Taste Adherence
 
@@ -122,11 +143,11 @@ After user selects their preferred design:
    ```
 6. **Cleanup:** Kill HTTP server, delete temp files under `/tmp/nopilot-preview-*`
 
-After completing UI Taste Exploration, proceed to Layer 3 (Requirement Lock). The selected mockups and design tokens are available for reference during requirement definition.
+After completing UI Taste Exploration, return the final screen summaries + `ui_taste` field data to the main agent. The main agent writes `ui_taste` to the discover artifact and proceeds to Layer 3.
 
 ---
 
-### Downstream Usage
+### Downstream Usage (informational — for main agent context)
 
 - **Layer 3:** When defining UI-related requirements, reference the selected mockups for specific elements
 - **`/spec` phase:** Reads `specs/mockups/` + `tokens.json` for component-level design

--- a/specs/features/feat-discover-context-diet/decisions.json
+++ b/specs/features/feat-discover-context-diet/decisions.json
@@ -1,0 +1,32 @@
+{
+  "decisions": [
+    {
+      "stage": "spec",
+      "timestamp": "2026-04-07T14:00:00Z",
+      "decision": "dispatch-protocol.md as standalone sub-skill file",
+      "alternatives": ["Embed protocol in SKILL.md header", "Inline in each sub-skill"],
+      "rationale": "Referenced by all sub-skills; single source of truth avoids duplication. ~1K file loaded once per session.",
+      "impact": "Adds one new file to the skill directory",
+      "impact_level": "low"
+    },
+    {
+      "stage": "spec",
+      "timestamp": "2026-04-07T14:00:00Z",
+      "decision": "Layer 1 and Layer 3 dispatch contracts remain in SKILL.md rather than separate files",
+      "alternatives": ["l1-dispatch.md and l3-dispatch.md as standalone files"],
+      "rationale": "These are dispatch annotations + summary presentation logic, not standalone sub-skill instructions. Keeping them in SKILL.md avoids unnecessary file proliferation.",
+      "impact": "SKILL.md grows slightly, but dispatch contracts are HTML comments",
+      "impact_level": "low"
+    },
+    {
+      "stage": "spec",
+      "timestamp": "2026-04-07T14:00:00Z",
+      "decision": "Subagent summaries not cached to files",
+      "alternatives": ["Write summaries to temp files for crash recovery"],
+      "rationale": "Summaries are < 3K chars and live in conversation context. On failure, subagent re-dispatch regenerates them.",
+      "impact": "No crash recovery for summaries, but subagent re-dispatch is fast",
+      "impact_level": "low"
+    }
+  ],
+  "contract_amendments": []
+}

--- a/specs/features/feat-discover-context-diet/discover/history.json
+++ b/specs/features/feat-discover-context-diet/discover/history.json
@@ -1,0 +1,44 @@
+{
+  "explored_directions": [],
+  "pruned_features": [],
+  "decision_log": [
+    {
+      "layer": "mvp",
+      "action": "APPROVE",
+      "detail": "Approved 8 MVP features (F1-F8): skill dedup, mode detection subagent, L1 research subagent, L3 generation subagent, artifact writing subagent, Stitch MCP subagent, dispatch contract standard, context budget guard. Design philosophy: main-agent-as-router, subagent-gets-full-context, fail-loud-user-decides.",
+      "timestamp": "2026-04-07T12:00:00Z"
+    },
+    {
+      "layer": "lock",
+      "action": "APPROVE",
+      "detail": "Approved 11 requirements (REQ-001~011), 3 invariants (INV-001~003), 3 scenarios. All challenges ACCEPT_COST: multi-round REVISE re-dispatch latency, MCP inheritance in subagent, cross-platform testing.",
+      "timestamp": "2026-04-07T12:30:00Z"
+    }
+  ],
+  "completeness_snapshots": [
+    {
+      "layer": "2",
+      "dimensions": {
+        "core_feature_definition": 95,
+        "user_scenario_coverage": 80,
+        "technical_constraints": 90,
+        "boundary_conditions": 70,
+        "non_functional_requirements": 80
+      },
+      "gaps_noted": ["subagent timeout/failure fallback strategy undefined"],
+      "timestamp": "2026-04-07T12:00:00Z"
+    },
+    {
+      "layer": "3",
+      "dimensions": {
+        "core_feature_definition": 100,
+        "user_scenario_coverage": 90,
+        "technical_constraints": 90,
+        "boundary_conditions": 85,
+        "non_functional_requirements": 90
+      },
+      "gaps_noted": [],
+      "timestamp": "2026-04-07T12:30:00Z"
+    }
+  ]
+}

--- a/specs/features/feat-discover-context-diet/discover/index.json
+++ b/specs/features/feat-discover-context-diet/discover/index.json
@@ -1,0 +1,140 @@
+{
+  "phase": "discover",
+  "version": "4.0",
+  "status": "approved",
+  "mode": "full",
+  "featureSlug": "discover-context-diet",
+  "profile_ref": ".nopilot/profile/",
+  "constraints": {
+    "tech_stack": ["TypeScript", "Node.js", "skill markdown (no new runtime code)"],
+    "time": null,
+    "platform": ["claude-code", "codex-cli", "opencode"],
+    "exclusions": ["No changes to user-visible interaction flow", "No changes to discover.json output schema"],
+    "budget": null,
+    "existing_assets": ["discover SKILL.md", "6 sub-skills (mode-detection, idea-intake, completeness, ui-taste, artifact-writer, critic-supervisor)"]
+  },
+  "selected_direction": {
+    "description": "extend existing project",
+    "differentiator": "n/a",
+    "rationale": "feature mode — direction inherited from existing codebase",
+    "pre_mortem": [],
+    "grounding": "ai_judgment_only"
+  },
+  "design_philosophy": [
+    {
+      "principle": "Main agent is a conversation router, not a compute engine",
+      "justification": "User confirmed subagent-first approach: all heavy computation runs in isolated subagent context, main agent only handles user dialogue + dispatch + summary presentation",
+      "source_decisions": ["F2-F7 subagent化"]
+    },
+    {
+      "principle": "Subagent gets full context, main agent gets minimal summary",
+      "justification": "User insight: we don't care about subagent context overflow, only main agent budget matters. Subagent reads full artifacts, returns structured summary.",
+      "source_decisions": ["方案D selection over A/B/C"]
+    },
+    {
+      "principle": "Fail loud, user decides recovery",
+      "justification": "User rejected silent fallback. On subagent failure: stop, report, ask user retry-or-fallback.",
+      "source_decisions": ["REQ-009"]
+    }
+  ],
+  "tech_direction": {
+    "stack": ["skill markdown files", "dispatch contract comments", "platform-agnostic subagent delegation"],
+    "architecture_style": "main-agent-as-router with subagent compute offload",
+    "product_impact": "Discover runs on 256K context models without compression, same UX and output",
+    "rationale": "Pure skill-layer change, no new runtime dependencies, three-platform compatible via each platform's native subagent mechanism"
+  },
+  "domain_model": {
+    "entities": [
+      { "name": "DispatchContract", "description": "Standardized declaration of subagent task: input files, output file, output summary format and max size" },
+      { "name": "ContextBudget", "description": "Per-stage context allocation target for main agent, declared in SKILL.md header" }
+    ],
+    "relationships": [
+      { "from": "SKILL.md", "to": "DispatchContract", "type": "contains", "description": "Each delegatable stage embeds a dispatch contract as HTML comment" },
+      { "from": "DispatchContract", "to": "sub-skill", "type": "references", "description": "Contract may reference sub-skill file for subagent to load" },
+      { "from": "ContextBudget", "to": "DispatchContract", "type": "constrains", "description": "Budget sets max output_summary size for each contract" }
+    ]
+  },
+  "non_functional_requirements": [
+    {
+      "category": "performance",
+      "description": "Main agent context consumption for complete discover run (greenfield, full mode, 3 rounds UI iteration)",
+      "target": "< 200K chars",
+      "source": "user_stated",
+      "priority": "must_have"
+    },
+    {
+      "category": "performance",
+      "description": "Backward compatibility: discover.json output schema unchanged",
+      "target": "Schema identical to v0.0.5",
+      "source": "user_stated",
+      "priority": "must_have"
+    },
+    {
+      "category": "availability",
+      "description": "Three-platform compatibility for dispatch contracts",
+      "target": "Claude Code, Codex CLI, OpenCode all execute correctly",
+      "source": "user_stated",
+      "priority": "must_have"
+    }
+  ],
+  "mvp_features": [
+    {
+      "name": "Skill dedup loading (F1)",
+      "feasibility": "High",
+      "competitive_notes": "Template fix, no platform dependency",
+      "source_refs": [],
+      "requirement_refs": ["REQ-001"]
+    },
+    {
+      "name": "Mode Detection subagent (F2)",
+      "feasibility": "High",
+      "competitive_notes": "Codebase scan is pure read-only, ideal for isolation",
+      "source_refs": [],
+      "requirement_refs": ["REQ-003"]
+    },
+    {
+      "name": "Layer 1 research subagent (F3)",
+      "feasibility": "High",
+      "competitive_notes": "WebFetch + analysis is independent compute",
+      "source_refs": [],
+      "requirement_refs": ["REQ-004"]
+    },
+    {
+      "name": "Layer 3 generation subagent (F4)",
+      "feasibility": "Medium",
+      "competitive_notes": "Needs full upstream artifact as input; multi-round REVISE adds complexity",
+      "source_refs": [],
+      "requirement_refs": ["REQ-005"]
+    },
+    {
+      "name": "Artifact Writing subagent (F5)",
+      "feasibility": "High",
+      "competitive_notes": "Pure file I/O, no user interaction needed",
+      "source_refs": [],
+      "requirement_refs": ["REQ-006"]
+    },
+    {
+      "name": "Stitch MCP subagent (F6)",
+      "feasibility": "Medium",
+      "competitive_notes": "MCP server connection inheritance in subagent process is a risk",
+      "source_refs": [],
+      "requirement_refs": ["REQ-007"]
+    },
+    {
+      "name": "Dispatch Contract standard (F7)",
+      "feasibility": "High",
+      "competitive_notes": "Convention definition, no code change",
+      "source_refs": [],
+      "requirement_refs": ["REQ-008", "REQ-009", "REQ-010"]
+    },
+    {
+      "name": "Context budget guard (F8)",
+      "feasibility": "Low (verification only)",
+      "competitive_notes": "Measured by testing, not enforced at runtime",
+      "source_refs": [],
+      "requirement_refs": ["REQ-011"]
+    }
+  ],
+  "context_dependencies": [],
+  "ui_taste": null
+}

--- a/specs/features/feat-discover-context-diet/discover/requirements.json
+++ b/specs/features/feat-discover-context-diet/discover/requirements.json
@@ -1,0 +1,288 @@
+{
+  "requirements": [
+    {
+      "id": "REQ-001",
+      "user_story": "As a developer, I want discover skill to load only once and arguments not duplicated, so that ~39K context is not wasted on duplicate injection and argument copying",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-001-AC-1",
+          "type": "condition",
+          "ears": "IF discover skill has already been injected into context, THEN Skill tool invocation SHALL return 'already loaded' without re-injecting content",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-001-AC-2",
+          "type": "event_driven",
+          "ears": "WHEN /discover command is invoked with arguments, THEN arguments SHALL appear only in the user message block, NOT appended to skill text as an ARGUMENTS section",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Modify SKILL.md template to remove ARGUMENTS append logic; add dedup guard for Skill tool re-invocation",
+        "test_complexity": "Low",
+        "effort_estimate": "< 1 hour"
+      }
+    },
+    {
+      "id": "REQ-003",
+      "user_story": "As a developer, I want codebase exploration to run in a subagent, so that main agent only receives a mode verdict (~500 chars) instead of 23K of file reads",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-003-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN mode detection begins, THEN a subagent SHALL be dispatched with contract { input: project root path, output_summary: 'mode=greenfield|feature + one-line rationale' }",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-003-AC-2",
+          "type": "condition",
+          "ears": "IF subagent returns, THEN main agent context increase SHALL be < 1K chars",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Rewrite mode-detection.md to use dispatch contract instead of inline Read/Glob",
+        "test_complexity": "Medium",
+        "effort_estimate": "2-3 hours"
+      }
+    },
+    {
+      "id": "REQ-004",
+      "user_story": "As a developer, I want competitive research and direction generation to run in a subagent, so that main agent only receives structured direction summaries (~2K) instead of 18K",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-004-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN Layer 1 direction generation begins, THEN a subagent SHALL be dispatched to perform competitive research and generate 3-5 directions",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-004-AC-2",
+          "type": "condition",
+          "ears": "IF subagent returns, THEN summary in main context SHALL contain direction name + differentiator + biggest risk per direction, total < 3K chars",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Add dispatch contract to SKILL.md Layer 1 section",
+        "test_complexity": "Medium",
+        "effort_estimate": "2-3 hours"
+      }
+    },
+    {
+      "id": "REQ-005",
+      "user_story": "As a developer, I want requirement lock table generation to run in a subagent reading the full artifact, so that main agent only receives a summary (~2K) instead of 24K",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-005-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN user approves Layer 2, THEN Layer 3 generation SHALL be dispatched to a subagent that reads all files under specs/discover/ (or specs/features/feat-{featureSlug}/discover/) directory",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-005-AC-2",
+          "type": "condition",
+          "ears": "IF subagent returns, THEN main agent SHALL receive requirement count + invariant count + high-risk items list, total < 3K chars",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-005-AC-3",
+          "type": "condition",
+          "ears": "IF user requests REVISE on specific requirements, THEN revision SHALL be dispatched to subagent with revision instructions",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Restructure SKILL.md Layer 3 to dispatch-first; main agent only presents summary and collects user actions",
+        "test_complexity": "Medium",
+        "effort_estimate": "3-4 hours"
+      }
+    },
+    {
+      "id": "REQ-006",
+      "user_story": "As a developer, I want artifact JSON construction and file writing to run in a subagent, so that main agent only receives a completion confirmation (~500 chars) instead of 22K",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-006-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN Layer 3 is approved, THEN artifact writing SHALL be dispatched to a subagent",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-006-AC-2",
+          "type": "condition",
+          "ears": "IF subagent returns, THEN main agent SHALL receive 'artifact written to [path]' confirmation, < 500 chars",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Wrap artifact-writer.md as subagent dispatch target",
+        "test_complexity": "Low",
+        "effort_estimate": "1-2 hours"
+      }
+    },
+    {
+      "id": "REQ-007",
+      "user_story": "As a developer, I want all Stitch MCP calls to run in a subagent, returning only screen ID + description summary (~1K per screen), so that 353K of raw component JSON never enters main context",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-007-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN UI Taste exploration calls Stitch MCP, THEN all Stitch calls SHALL execute in a subagent",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-007-AC-2",
+          "type": "condition",
+          "ears": "IF subagent returns screen results, THEN summary SHALL contain screen ID + one-line visual description per screen, total < 2K per batch",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-007-AC-3",
+          "type": "condition",
+          "ears": "IF user requests iteration on specific screens, THEN iteration dispatch SHALL include user feedback + target screen IDs",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Rewrite ui-taste.md to use dispatch contract for all Stitch interactions",
+        "test_complexity": "Medium",
+        "effort_estimate": "3-4 hours"
+      }
+    },
+    {
+      "id": "REQ-008",
+      "user_story": "As a developer, I want each subagent dispatch to follow a standardized contract, so that behavior is consistent across stages and platforms",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-008-AC-1",
+          "type": "state",
+          "ears": "EVERY dispatch contract SHALL contain: task (string), input (file paths), output_file (path), output_summary (format + max size)",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-008-AC-2",
+          "type": "state",
+          "ears": "EVERY dispatch contract SHALL be written as HTML comment block <!-- DISPATCH CONTRACT ... --> in the skill markdown",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Define dispatch contract schema; embed in all affected sub-skills",
+        "test_complexity": "Low",
+        "effort_estimate": "1 hour"
+      }
+    },
+    {
+      "id": "REQ-009",
+      "user_story": "As a developer, I want the system to stop and ask me 'retry or fallback?' when a subagent dispatch fails, so that I maintain control over error recovery",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-009-AC-1",
+          "type": "event_driven",
+          "ears": "WHEN subagent dispatch fails (timeout/error/unsupported), THEN main agent SHALL stop and present error to user",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-009-AC-2",
+          "type": "event_driven",
+          "ears": "WHEN error is presented, THEN main agent SHALL ask 'retry or fallback to main agent execution?'",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-009-AC-3",
+          "type": "condition",
+          "ears": "IF user chooses fallback, THEN main agent SHALL execute the stage inline with a warning about increased context consumption",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-009-AC-4",
+          "type": "event_driven",
+          "ears": "WHEN subagent dispatch fails after partial output_file write, THEN the partial file SHALL be deleted before retry or fallback",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Add error handling template to dispatch contract standard; include partial file cleanup step",
+        "test_complexity": "Low",
+        "effort_estimate": "1 hour"
+      }
+    },
+    {
+      "id": "REQ-010",
+      "user_story": "As a developer, I want dispatch contracts to be platform-agnostic, so that Claude Code / Codex / OpenCode all execute the same discover skill correctly",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-010-AC-1",
+          "type": "state",
+          "ears": "Dispatch contracts SHALL use platform-agnostic language (no Claude Code-specific tool names)",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-010-AC-2",
+          "type": "state",
+          "ears": "Each platform's AI agent SHALL interpret dispatch contracts and invoke subagents using that platform's native mechanism (Claude Code: Agent tool, Codex CLI: subagent spawn, OpenCode: Task tool)",
+          "source_refs": []
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Review all dispatch contracts for platform-specific language; document mapping for Codex TOML and OpenCode YAML",
+        "test_complexity": "Medium",
+        "effort_estimate": "2-3 hours"
+      }
+    },
+    {
+      "id": "REQ-011",
+      "user_story": "As a developer, I want the total main-agent context to stay under 200K chars for a complete discover run, so that the skill works on 256K context models",
+      "acceptance_criteria": [
+        {
+          "id": "REQ-011-AC-1",
+          "type": "condition",
+          "ears": "IF a complete discover run (greenfield, full mode, 3 rounds UI iteration) completes, THEN cumulative main-agent user+assistant message content (excluding system prompts and tool schemas) SHALL be < 200K chars",
+          "source_refs": []
+        },
+        {
+          "id": "REQ-011-AC-2",
+          "type": "regression_guard",
+          "ears": "THE SYSTEM SHALL continue to produce identical discover.json artifact structure when context-diet optimizations are applied",
+          "source_refs": ["INV-001"]
+        }
+      ],
+      "source": "user_stated",
+      "downstream_impact": {
+        "tech_implications": "Verification via simulated discover run with context measurement",
+        "test_complexity": "Medium",
+        "effort_estimate": "2-3 hours (testing)"
+      }
+    }
+  ],
+  "invariants": [
+    {
+      "id": "INV-001",
+      "statement": "discover.json output schema SHALL remain unchanged regardless of subagent usage",
+      "scope": "system-wide",
+      "requirement_refs": ["REQ-003", "REQ-004", "REQ-005", "REQ-006", "REQ-007"]
+    },
+    {
+      "id": "INV-002",
+      "statement": "User-visible interaction flow (questions, choices, confirmations) SHALL remain functionally identical",
+      "scope": "system-wide",
+      "requirement_refs": ["REQ-001", "REQ-003", "REQ-004", "REQ-005", "REQ-006", "REQ-007"]
+    },
+    {
+      "id": "INV-003",
+      "statement": "All user decisions SHALL be persisted to artifact files before any subagent dispatch that depends on them",
+      "scope": "system-wide",
+      "requirement_refs": ["REQ-005", "REQ-006", "REQ-007"]
+    }
+  ]
+}

--- a/specs/features/feat-discover-context-diet/discover/scenarios.json
+++ b/specs/features/feat-discover-context-diet/discover/scenarios.json
@@ -1,0 +1,22 @@
+{
+  "core_scenarios": [
+    {
+      "id": "SCENARIO-001",
+      "description": "Complete greenfield discover on 256K model: User runs /discover with product spec → mode detection (subagent) → idea structuring (main) → direction selection (subagent research + main presentation) → MVP definition (main) → UI taste (subagent Stitch + main presentation, 3 rounds) → requirement lock (subagent generation + main confirmation) → artifact writing (subagent) → critic/supervisor (pre-existing dispatch, out of scope for this feature). Stages marked '(main)' stay in main agent: idea structuring (~4K) and MVP definition (~6K) are lightweight interactive stages not worth subagent overhead. Total main-agent context < 200K.",
+      "requirement_refs": ["REQ-001", "REQ-003", "REQ-004", "REQ-005", "REQ-006", "REQ-007", "REQ-008", "REQ-011"],
+      "priority": "highest"
+    },
+    {
+      "id": "SCENARIO-002",
+      "description": "Subagent failure recovery: During any dispatch, subagent times out or errors → main agent stops, shows error, asks 'retry or fallback?' → user chooses fallback → stage executes inline in main agent with context warning → discover completes (possibly exceeding 200K budget but functionally correct).",
+      "requirement_refs": ["REQ-009"],
+      "priority": "high"
+    },
+    {
+      "id": "SCENARIO-003",
+      "description": "Cross-platform execution: Same discover skill files run on Codex CLI and OpenCode with their native subagent mechanisms. Dispatch contracts are interpreted correctly. Output artifacts are identical.",
+      "requirement_refs": ["REQ-010"],
+      "priority": "high"
+    }
+  ]
+}

--- a/specs/features/feat-discover-context-diet/discover_review.json
+++ b/specs/features/feat-discover-context-diet/discover_review.json
@@ -1,0 +1,56 @@
+{
+  "critic_review": {
+    "passed": true,
+    "block_count": 0,
+    "warn_count": 0,
+    "revision_applied": "All 4 MAJOR and 4 MINOR findings addressed in revision",
+    "revisions": [
+      "MAJOR-1: REQ-010-AC-2 rewritten from 'skill engine SHALL map' to 'AI agent SHALL interpret using platform native mechanism' with concrete examples",
+      "MAJOR-2: INV-003 requirement_refs expanded to include REQ-007",
+      "MAJOR-3: REQ-001 and REQ-002 merged into single REQ-001 with 2 ACs",
+      "MAJOR-4: SCENARIO-001 updated to mark critic-supervisor as pre-existing out-of-scope",
+      "MINOR: REQ-003-AC-1 'input: codebase' → 'input: project root path'",
+      "MINOR: REQ-005-AC-1 'reads index.json' → 'reads all files under discover/ directory'",
+      "MINOR: REQ-011-AC-1 measurement clarified to 'user+assistant message content excluding system prompts'",
+      "MINOR: REQ-009-AC-4 added for partial file cleanup on subagent failure"
+    ],
+    "reverification": {
+      "passed": true,
+      "block_count": 0,
+      "warn_count": 0,
+      "fix_verification_summary": "8/8 fixes applied correctly, all resolve original issues, no new problems introduced",
+      "6cs_audit": { "passed": true, "findings": [] },
+      "invariant_verification": { "passed": true, "findings": [] },
+      "acceptance_criteria_verification": { "passed": true, "findings": [] },
+      "coverage_verification": { "passed": true, "findings": [] }
+    },
+    "6cs_audit": {
+      "passed": true,
+      "findings": []
+    },
+    "invariant_verification": {
+      "passed": true,
+      "findings": []
+    },
+    "acceptance_criteria_verification": {
+      "passed": true,
+      "findings": []
+    },
+    "coverage_verification": {
+      "passed": true,
+      "findings": []
+    }
+  },
+  "global_coherence_check": {
+    "drift_detected": false,
+    "drift_score": 3,
+    "aligned": true,
+    "findings": [
+      { "area": "mvp_features ↔ requirements", "severity": "info", "detail": "Perfect bidirectional coverage. All 10 requirements map to MVP features; all 8 MVP features have requirement_refs." },
+      { "area": "design_philosophy ↔ requirements", "severity": "info", "detail": "All 3 principles (router-not-engine, subagent-full-context, fail-loud) have direct requirement coverage." },
+      { "area": "constraints ↔ requirements", "severity": "info", "detail": "Tech stack constraint 'skill markdown, no new runtime code' respected by all downstream_impact entries." },
+      { "area": "non_functional_requirements ↔ acceptance_criteria", "severity": "info", "detail": "All 3 NFRs have matching ACs: REQ-011-AC-1, REQ-011-AC-2 + INV-001, REQ-010-AC-1/AC-2." },
+      { "area": "tech_direction ↔ downstream_impact", "severity": "info", "detail": "Architecture 'main-agent-as-router' consistently reflected. No requirement implies runtime code changes." }
+    ]
+  }
+}

--- a/specs/features/feat-discover-context-diet/spec.json
+++ b/specs/features/feat-discover-context-diet/spec.json
@@ -1,0 +1,849 @@
+{
+  "phase": "spec",
+  "version": "4.0",
+  "status": "approved",
+  "featureSlug": "discover-context-diet",
+  "profile_ref": ".nopilot/profile/",
+  "modules": [
+    {
+      "id": "MOD-A",
+      "name": "skill-orchestrator",
+      "responsibility": "Main SKILL.md: dedup guard (AC-1: skip re-injection, AC-2: remove ARGUMENTS append from template), context budget declaration, dispatch routing for all subagent stages, user interaction loop for summaries and confirmations",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "dedup-guard",
+          "input_schema": {
+            "skill_already_loaded": "boolean (detect from conversation context)"
+          },
+          "output_schema": {
+            "action": "'skip' | 'load'"
+          },
+          "errors": [],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-001"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-001-AC-1"
+          ]
+        },
+        {
+          "type": "internal",
+          "name": "dispatch-router",
+          "input_schema": {
+            "stage": "string (mode_detection | layer1 | layer3 | artifact | ui_taste)",
+            "context": "object (user decisions so far)"
+          },
+          "output_schema": {
+            "dispatch_contract": "DispatchContract",
+            "summary": "string"
+          },
+          "errors": [
+            "subagent_timeout",
+            "subagent_error",
+            "platform_unsupported"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-008",
+            "REQ-009",
+            "REQ-010"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-008-AC-1",
+            "REQ-008-AC-2",
+            "REQ-009-AC-1",
+            "REQ-009-AC-2",
+            "REQ-009-AC-3",
+            "REQ-009-AC-4"
+          ]
+        }
+      ],
+      "data_models": [
+        {
+          "name": "ContextBudget",
+          "fields": [
+            {
+              "name": "total_target",
+              "type": "string",
+              "constraints": "< 200K chars (design-time declaration, verified by testing, not enforced at runtime)"
+            },
+            {
+              "name": "measurement_scope",
+              "type": "string",
+              "constraints": "user+assistant message content, excluding system prompts and tool schemas"
+            },
+            {
+              "name": "per_stage_targets",
+              "type": "object",
+              "constraints": "mode_detection: <1K, layer1: <3K, layer3: <3K, artifact: <500, ui_taste: <2K per batch (design-time targets)"
+            }
+          ],
+          "relationships": []
+        }
+      ],
+      "state_machine": {
+        "states": [
+          "init",
+          "skill_loaded",
+          "mode_dispatched",
+          "mode_received",
+          "idea_structuring",
+          "L1_dispatched",
+          "L1_summary_received",
+          "L1_completeness",
+          "L2_mvp",
+          "L2_completeness",
+          "design_philosophy",
+          "ui_dispatched",
+          "ui_summary_received",
+          "L3_dispatched",
+          "L3_summary_received",
+          "L3_completeness",
+          "artifact_dispatched",
+          "artifact_confirmed",
+          "critic_dispatched",
+          "supervisor_dispatched",
+          "done"
+        ],
+        "error_states": [
+          "error_presented",
+          "fallback_inline"
+        ],
+        "note": "Completeness assessments and design philosophy extraction are existing behaviors preserved by INV-002. They run inline in main agent (lightweight, ~3K each). Not subagent-ified.",
+        "transitions": [
+          {
+            "from": "init",
+            "to": "skill_loaded",
+            "event": "skill_injected (dedup guard passes)"
+          },
+          {
+            "from": "skill_loaded",
+            "to": "mode_dispatched",
+            "event": "dispatch MOD-B"
+          },
+          {
+            "from": "mode_dispatched",
+            "to": "mode_received",
+            "event": "subagent returns summary"
+          },
+          {
+            "from": "mode_received",
+            "to": "idea_structuring",
+            "event": "present mode to user"
+          },
+          {
+            "from": "idea_structuring",
+            "to": "L1_dispatched",
+            "event": "mode=greenfield, user confirms constraints"
+          },
+          {
+            "from": "idea_structuring",
+            "to": "L2_mvp",
+            "event": "mode=feature, skip Layer 1"
+          },
+          {
+            "from": "L1_dispatched",
+            "to": "L1_summary_received",
+            "event": "subagent returns directions"
+          },
+          {
+            "from": "L1_summary_received",
+            "to": "L1_completeness",
+            "event": "user selects direction"
+          },
+          {
+            "from": "L1_completeness",
+            "to": "L2_mvp",
+            "event": "completeness passes"
+          },
+          {
+            "from": "L2_mvp",
+            "to": "L2_completeness",
+            "event": "user approves L2"
+          },
+          {
+            "from": "L2_completeness",
+            "to": "design_philosophy",
+            "event": "completeness passes (greenfield)"
+          },
+          {
+            "from": "L2_completeness",
+            "to": "ui_dispatched",
+            "event": "completeness passes (feature) + has UI"
+          },
+          {
+            "from": "L2_completeness",
+            "to": "L3_dispatched",
+            "event": "completeness passes + no UI"
+          },
+          {
+            "from": "design_philosophy",
+            "to": "ui_dispatched",
+            "event": "philosophy confirmed + has UI"
+          },
+          {
+            "from": "design_philosophy",
+            "to": "L3_dispatched",
+            "event": "philosophy confirmed + no UI"
+          },
+          {
+            "from": "ui_dispatched",
+            "to": "ui_summary_received",
+            "event": "subagent returns screen summaries"
+          },
+          {
+            "from": "ui_summary_received",
+            "to": "ui_dispatched",
+            "event": "user requests iteration"
+          },
+          {
+            "from": "ui_summary_received",
+            "to": "L3_dispatched",
+            "event": "user approves UI"
+          },
+          {
+            "from": "L3_dispatched",
+            "to": "L3_summary_received",
+            "event": "subagent returns req summary"
+          },
+          {
+            "from": "L3_summary_received",
+            "to": "L3_dispatched",
+            "event": "user REVISE"
+          },
+          {
+            "from": "L3_summary_received",
+            "to": "L3_completeness",
+            "event": "user APPROVE"
+          },
+          {
+            "from": "L3_completeness",
+            "to": "artifact_dispatched",
+            "event": "all dims >= 70%"
+          },
+          {
+            "from": "artifact_dispatched",
+            "to": "artifact_confirmed",
+            "event": "subagent confirms write"
+          },
+          {
+            "from": "artifact_confirmed",
+            "to": "critic_dispatched",
+            "event": "dispatch critic"
+          },
+          {
+            "from": "critic_dispatched",
+            "to": "supervisor_dispatched",
+            "event": "critic passes"
+          },
+          {
+            "from": "critic_dispatched",
+            "to": "L3_dispatched",
+            "event": "critic rejects, user resolves"
+          },
+          {
+            "from": "supervisor_dispatched",
+            "to": "done",
+            "event": "supervisor aligned"
+          },
+          {
+            "from": "supervisor_dispatched",
+            "to": "L3_dispatched",
+            "event": "supervisor detects drift, user resolves"
+          },
+          {
+            "from": "*_dispatched",
+            "to": "error_presented",
+            "event": "subagent fails"
+          },
+          {
+            "from": "error_presented",
+            "to": "*_dispatched",
+            "event": "user chooses retry (partial files cleaned)"
+          },
+          {
+            "from": "error_presented",
+            "to": "fallback_inline",
+            "event": "user chooses fallback (context warning shown)"
+          }
+        ]
+      },
+      "nfr_constraints": {
+        "performance": "Total main-agent context < 200K chars for complete greenfield discover run with 3 UI iteration rounds",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-001",
+        "REQ-008",
+        "REQ-009",
+        "REQ-010",
+        "REQ-011"
+      ],
+      "invariant_refs": [
+        "INV-001",
+        "INV-002",
+        "INV-003"
+      ]
+    },
+    {
+      "id": "MOD-B",
+      "name": "mode-detection-agent",
+      "responsibility": "Subagent dispatch target: explore codebase to determine greenfield/feature mode. Reads project files, checks for .nopilot/profile/, scans source code. Returns structured mode verdict.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "detect-mode",
+          "input_schema": {
+            "project_root": "string (absolute path)"
+          },
+          "output_schema": {
+            "mode": "'greenfield' | 'feature'",
+            "rationale": "string (one-line)"
+          },
+          "errors": [
+            "no_read_access",
+            "empty_directory"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-003"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-003-AC-1",
+            "REQ-003-AC-2"
+          ]
+        }
+      ],
+      "data_models": [],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "Output summary < 1K chars",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-003"
+      ],
+      "invariant_refs": [
+        "INV-002"
+      ]
+    },
+    {
+      "id": "MOD-C",
+      "name": "layer1-research-agent",
+      "responsibility": "Subagent dispatch target: competitive research + direction generation. Reads discover index.json for constraints and idea. Searches web, generates 3-5 directions. Returns structured summaries.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "research-directions",
+          "input_schema": {
+            "discover_index": "string (path to index.json)"
+          },
+          "output_schema": {
+            "directions": [
+              {
+                "name": "string",
+                "description": "string",
+                "differentiator": "string",
+                "biggest_risk": "string",
+                "grounding": "'search_verified' | 'ai_judgment_only'"
+              }
+            ]
+          },
+          "errors": [
+            "search_failed",
+            "index_not_found"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-004"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-004-AC-1",
+            "REQ-004-AC-2"
+          ]
+        }
+      ],
+      "data_models": [],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "Output summary < 3K chars",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-004"
+      ],
+      "invariant_refs": [
+        "INV-002"
+      ]
+    },
+    {
+      "id": "MOD-D",
+      "name": "layer3-generation-agent",
+      "responsibility": "Subagent dispatch target: generate Layer 3 requirement lock table from full discover artifact. Produces requirements, invariants, scenarios with EARS criteria. Supports revision dispatches.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "generate-requirements",
+          "input_schema": {
+            "discover_dir": "string (path to discover/ directory with all files)"
+          },
+          "output_schema": {
+            "summary": {
+              "requirement_count": "number",
+              "invariant_count": "number",
+              "high_risk_items": [
+                {
+                  "id": "string",
+                  "summary": "string"
+                }
+              ],
+              "conflicts": "string[]"
+            }
+          },
+          "errors": [
+            "discover_dir_not_found",
+            "incomplete_layer2"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-005"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-005-AC-1",
+            "REQ-005-AC-2"
+          ]
+        },
+        {
+          "type": "internal",
+          "name": "revise-requirements",
+          "input_schema": {
+            "discover_dir": "string",
+            "revision_instructions": "string (user feedback on specific REQ IDs)"
+          },
+          "output_schema": {
+            "summary": "same as generate-requirements"
+          },
+          "errors": [
+            "req_id_not_found"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-005"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-005-AC-3"
+          ]
+        }
+      ],
+      "data_models": [],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "Output summary < 3K chars",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-005"
+      ],
+      "invariant_refs": [
+        "INV-003",
+        "INV-002"
+      ]
+    },
+    {
+      "id": "MOD-E",
+      "name": "artifact-writer-agent",
+      "responsibility": "Subagent dispatch target: read sub-skill instructions, construct final discover JSON artifacts, write to file system. Returns file list confirmation.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "write-artifacts",
+          "input_schema": {
+            "discover_dir": "string",
+            "artifact_writer_skill": "string (path to artifact-writer.md)"
+          },
+          "output_schema": {
+            "written": "string[] (file paths)",
+            "format": "'single' | 'split'"
+          },
+          "errors": [
+            "write_permission_denied",
+            "skill_not_found"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-006"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-006-AC-1",
+            "REQ-006-AC-2"
+          ]
+        }
+      ],
+      "data_models": [],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "Output confirmation < 500 chars",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-006"
+      ],
+      "invariant_refs": [
+        "INV-001",
+        "INV-002"
+      ]
+    },
+    {
+      "id": "MOD-F",
+      "name": "ui-taste-agent",
+      "responsibility": "Subagent dispatch target: execute all Stitch MCP interactions (generate_screen_from_text, generate_variants) in isolated context. Returns screen ID + description summaries. Supports iteration with user feedback.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "generate-screens",
+          "input_schema": {
+            "discover_index": "string (path to index.json for designDNA)",
+            "pages": [
+              {
+                "name": "string",
+                "description": "string",
+                "device_type": "string"
+              }
+            ],
+            "design_constraints": "string | null"
+          },
+          "output_schema": {
+            "screens": [
+              {
+                "id": "string",
+                "page_name": "string",
+                "description": "string",
+                "variant_count": "number"
+              }
+            ],
+            "stitch_project_id": "string | null",
+            "preview_url": "string | null"
+          },
+          "errors": [
+            "stitch_mcp_unavailable",
+            "stitch_api_error",
+            "mcp_not_inherited"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-007"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-007-AC-1",
+            "REQ-007-AC-2"
+          ]
+        },
+        {
+          "type": "internal",
+          "name": "iterate-screens",
+          "input_schema": {
+            "screen_ids": "string[]",
+            "user_feedback": "string",
+            "stitch_project_id": "string | null"
+          },
+          "output_schema": {
+            "screens": "same as generate-screens"
+          },
+          "errors": [
+            "screen_id_not_found",
+            "stitch_mcp_unavailable"
+          ],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-007"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-007-AC-3"
+          ]
+        }
+      ],
+      "data_models": [],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "Output summary < 2K chars per batch",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-007"
+      ],
+      "invariant_refs": [
+        "INV-001",
+        "INV-002",
+        "INV-003"
+      ]
+    },
+    {
+      "id": "MOD-G",
+      "name": "dispatch-protocol",
+      "responsibility": "New sub-skill file defining the standard dispatch contract template, error handling protocol, and platform-agnostic invocation guidelines. Referenced by all other modules.",
+      "interfaces": [
+        {
+          "type": "internal",
+          "name": "dispatch-contract-template",
+          "input_schema": {
+            "task": "string",
+            "input": "string[]",
+            "instructions": "string",
+            "output_file": "string | null",
+            "output_summary": "{ format: string, max_size: string }"
+          },
+          "output_schema": {
+            "html_comment_block": "string (<!-- DISPATCH CONTRACT ... -->)"
+          },
+          "errors": [],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-008"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-008-AC-1",
+            "REQ-008-AC-2"
+          ]
+        },
+        {
+          "type": "internal",
+          "name": "error-handling-protocol",
+          "input_schema": {
+            "error_type": "'timeout' | 'error' | 'unsupported'",
+            "partial_output_file": "string | null",
+            "domain_error_mapping": "All domain-specific errors (no_read_access, empty_directory, search_failed, index_not_found, discover_dir_not_found, incomplete_layer2, write_permission_denied, skill_not_found, stitch_mcp_unavailable, stitch_api_error, mcp_not_inherited, screen_id_not_found, req_id_not_found) map to category 'error'. Only network/process hangs map to 'timeout'. Platform lacking subagent support maps to 'unsupported'."
+          },
+          "output_schema": {
+            "action": "'retry' | 'fallback'",
+            "cleanup_required": "boolean"
+          },
+          "errors": [],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-009"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-009-AC-1",
+            "REQ-009-AC-2",
+            "REQ-009-AC-3",
+            "REQ-009-AC-4"
+          ]
+        },
+        {
+          "type": "internal",
+          "name": "platform-invocation-guide",
+          "input_schema": {},
+          "output_schema": {
+            "claude_code": "Agent tool",
+            "codex_cli": "subagent spawn",
+            "opencode": "Task tool"
+          },
+          "errors": [],
+          "api_detail": null,
+          "requirement_refs": [
+            "REQ-010"
+          ],
+          "acceptance_criteria_refs": [
+            "REQ-010-AC-1",
+            "REQ-010-AC-2"
+          ]
+        }
+      ],
+      "data_models": [
+        {
+          "name": "DispatchContract",
+          "fields": [
+            {
+              "name": "task",
+              "type": "string",
+              "constraints": "required, describes what the subagent does"
+            },
+            {
+              "name": "input",
+              "type": "string[]",
+              "constraints": "required, file paths or directory paths"
+            },
+            {
+              "name": "instructions",
+              "type": "string",
+              "constraints": "required, sub-skill path or inline instructions"
+            },
+            {
+              "name": "output_file",
+              "type": "string | null",
+              "constraints": "file path for subagent to write results"
+            },
+            {
+              "name": "output_summary",
+              "type": "object",
+              "constraints": "required: format description + max_size"
+            },
+            {
+              "name": "on_error",
+              "type": "string",
+              "constraints": "'standard' references the error handling protocol"
+            }
+          ],
+          "relationships": []
+        }
+      ],
+      "state_machine": null,
+      "nfr_constraints": {
+        "performance": "File size < 2K chars (loaded once per session)",
+        "security": null,
+        "other": null
+      },
+      "requirement_refs": [
+        "REQ-008",
+        "REQ-009",
+        "REQ-010"
+      ],
+      "invariant_refs": [
+        "INV-002"
+      ]
+    }
+  ],
+  "dependency_graph": {
+    "edges": [
+      {
+        "from": "MOD-A",
+        "to": "MOD-B",
+        "type": "calls"
+      },
+      {
+        "from": "MOD-A",
+        "to": "MOD-C",
+        "type": "calls"
+      },
+      {
+        "from": "MOD-A",
+        "to": "MOD-D",
+        "type": "calls"
+      },
+      {
+        "from": "MOD-A",
+        "to": "MOD-E",
+        "type": "calls"
+      },
+      {
+        "from": "MOD-A",
+        "to": "MOD-F",
+        "type": "calls"
+      },
+      {
+        "from": "MOD-A",
+        "to": "MOD-G",
+        "type": "depends"
+      },
+      {
+        "from": "MOD-B",
+        "to": "MOD-G",
+        "type": "depends"
+      },
+      {
+        "from": "MOD-C",
+        "to": "MOD-G",
+        "type": "depends"
+      },
+      {
+        "from": "MOD-D",
+        "to": "MOD-G",
+        "type": "depends"
+      },
+      {
+        "from": "MOD-E",
+        "to": "MOD-G",
+        "type": "depends"
+      },
+      {
+        "from": "MOD-F",
+        "to": "MOD-G",
+        "type": "depends"
+      }
+    ],
+    "existing_module_refs": [
+      {
+        "name": "taste-orchestrator (L1 MOD-009)",
+        "path": "src/ui-taste",
+        "relationship": "MOD-F wraps the existing taste-orchestrator's Stitch interactions; the runtime module is unchanged, only the skill-layer invocation pattern changes"
+      }
+    ]
+  },
+  "external_dependencies": [
+    {
+      "name": "Platform subagent mechanism",
+      "purpose": "Execute dispatch contracts in isolated context (Claude Code: Agent tool, Codex CLI: subagent spawn, OpenCode: Task tool)",
+      "module_refs": [
+        "MOD-A",
+        "MOD-B",
+        "MOD-C",
+        "MOD-D",
+        "MOD-E",
+        "MOD-F"
+      ],
+      "alternatives": [
+        "Fallback to inline main-agent execution (REQ-009)"
+      ],
+      "test_strategy": "real"
+    },
+    {
+      "name": "Stitch MCP (optional)",
+      "purpose": "UI mockup generation in MOD-F",
+      "module_refs": [
+        "MOD-F"
+      ],
+      "alternatives": [
+        "Tier 2 HTML fallback",
+        "Tier 3 text-based questions"
+      ],
+      "test_strategy": "real"
+    }
+  ],
+  "global_error_strategy": {
+    "api_error_format": "N/A (no API — skill markdown instructions only)",
+    "external_service": "Subagent dispatch failure: stop → present error → ask user retry/fallback → cleanup partial files → execute chosen path (REQ-009)",
+    "logging": "N/A (no runtime logging — dispatch results visible in conversation context)"
+  },
+  "auto_decisions": [
+    {
+      "decision": "dispatch-protocol.md as standalone sub-skill file",
+      "alternatives": [
+        "Embed protocol in SKILL.md header",
+        "Inline in each sub-skill"
+      ],
+      "rationale": "Referenced by all sub-skills; single source of truth avoids duplication. ~1K file loaded once per session.",
+      "impact": "Adds one new file to the skill directory",
+      "impact_level": "low"
+    },
+    {
+      "decision": "Layer 1 and Layer 3 dispatch contracts remain in SKILL.md rather than separate files",
+      "alternatives": [
+        "l1-dispatch.md and l3-dispatch.md as standalone files"
+      ],
+      "rationale": "These are dispatch annotations + summary presentation logic, not standalone sub-skill instructions. Keeping them in SKILL.md avoids unnecessary file proliferation.",
+      "impact": "SKILL.md grows slightly, but dispatch contracts are HTML comments (invisible to non-markdown tools)",
+      "impact_level": "low"
+    },
+    {
+      "decision": "Subagent summaries not cached to files",
+      "alternatives": [
+        "Write summaries to temp files for crash recovery"
+      ],
+      "rationale": "Summaries are < 3K chars and live in conversation context. On failure, subagent re-dispatch regenerates them. Caching adds complexity without meaningful benefit.",
+      "impact": "No crash recovery for summaries, but subagent re-dispatch is fast",
+      "impact_level": "low"
+    }
+  ],
+  "contract_amendments": [],
+  "context_dependencies": [
+    "specs/features/feat-discover-context-diet/discover/index.json"
+  ]
+}

--- a/specs/features/feat-discover-context-diet/spec_review.json
+++ b/specs/features/feat-discover-context-diet/spec_review.json
@@ -1,0 +1,39 @@
+{
+  "critic_review": {
+    "passed": true,
+    "block_count": 0,
+    "warn_count": 0,
+    "initial_review": "REVISE (1 block: state machine missing feature-mode/no-UI paths, 6 warn)",
+    "revisions_applied": [
+      "BLOCK: State machine expanded with feature-mode skip L1, no-UI skips, completeness states, design_philosophy state, fallback_inline, critic/supervisor rejection loops",
+      "WARN: MOD-B output_schema simplified to greenfield|feature only",
+      "WARN: ContextBudget annotated as design-time declaration",
+      "WARN: REQ-001-AC-2 explicitly in MOD-A responsibility",
+      "WARN: MOD-B existing_modules field removed",
+      "WARN: MOD-F invariant_refs = [INV-001, INV-002, INV-003]",
+      "WARN: INV-002 added to MOD-B, MOD-C, MOD-D, MOD-E",
+      "ADDITIONAL: Domain error mapping in MOD-G error-handling-protocol"
+    ],
+    "reverification": {
+      "passed": true,
+      "fix_verification_summary": "8/8 fixes applied correctly, all resolve original issues, no new problems",
+      "backward_verification": { "passed": true, "findings": [] },
+      "traceability_audit": { "passed": true, "findings": [] },
+      "module_coherence": { "passed": true, "findings": [] }
+    }
+  },
+  "global_coherence_check": {
+    "drift_detected": false,
+    "drift_score": 8,
+    "drift_diagnosis": "Spec faithfully implements discover intent. Star topology matches main-agent-as-router architecture. All subagent outputs bounded. Skill markdown only constraint respected.",
+    "aligned": true,
+    "findings": [
+      { "area": "constraint compliance", "severity": "info", "detail": "All 7 modules represent markdown file changes. No runtime code introduced." },
+      { "area": "design philosophy: router-not-compute", "severity": "info", "detail": "MOD-A only routes and presents. No compute inline." },
+      { "area": "design philosophy: bounded summaries", "severity": "info", "detail": "All 5 subagent modules declare output size constraints matching requirement ACs." },
+      { "area": "design philosophy: fail-loud", "severity": "info", "detail": "Error handling consistent. Domain error mapping added to MOD-G." },
+      { "area": "module count", "severity": "info", "detail": "7 modules justified by file boundaries. No merge candidates." },
+      { "area": "dependency graph", "severity": "info", "detail": "Clean star topology. MOD-A hub, MOD-B-F spokes, MOD-G shared protocol." }
+    ]
+  }
+}

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -484,3 +484,120 @@ describe('Property tests', () => {
     expect(failures, `DISPATCH CONTRACT output_file not in specs/: ${failures.join(', ')}`).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Context budget e2e tests for PR #60
+// ---------------------------------------------------------------------------
+
+describe('Context budget e2e tests (PR #60)', () => {
+  it('TEST-070-001: dispatch-protocol.md exists and defines context budget', () => {
+    const content = readFile('commands/discover/dispatch-protocol.md');
+    expect(content).toContain('Context Budget');
+    expect(content).toContain('< 200K chars');
+    expect(content).toContain('Mode Detection: < 1K chars');
+    expect(content).toContain('Layer 1 Research: < 3K chars');
+    expect(content).toContain('Layer 3 Generation: < 3K chars');
+    expect(content).toContain('Artifact Writing: < 500 chars');
+    expect(content).toContain('UI Taste (per batch): < 2K chars');
+  });
+
+  it('TEST-070-002: SKILL.md contains DISPATCH CONTRACT blocks', () => {
+    const content = readFile('commands/discover/SKILL.md');
+    expect(content).toContain('DISPATCH CONTRACT');
+    
+    // Count dispatch contracts
+    const contracts = content.match(/<!--\s*DISPATCH CONTRACT[\s\S]*?-->/g);
+    expect(contracts).toBeDefined();
+    expect(contracts!.length).toBeGreaterThan(0);
+  });
+
+  it('TEST-070-003: mode-detection.md has valid dispatch contract with correct output summary format', () => {
+    const content = readFile('commands/discover/mode-detection.md');
+    expect(content).toContain('DISPATCH CONTRACT');
+    // Format: output <= 500 chars, max 20 items
+    expect(content).toMatch(/output\s*<=\s*500\s*chars.*max\s*\d+\s*items/);
+    
+    // Verify output format specification
+    expect(content).toContain('mode: greenfield | feature');
+    expect(content).toContain('rationale:');
+    expect(content).toContain('profile_stale:');
+    expect(content).toContain('Keep total output under 500 chars');
+  });
+
+  it('TEST-070-004: ui-taste.md has valid dispatch contract with correct output summary format', () => {
+    const content = readFile('commands/discover/ui-taste.md');
+    expect(content).toContain('DISPATCH CONTRACT');
+    // Format: output <= 2K chars per batch, max 20 items
+    expect(content).toMatch(/output\s*<=\s*2K\s*chars.*per batch.*max\s*\d+\s*items/);
+    
+    // Verify output format specification
+    expect(content).toMatch(/screens:.*id:.*page:.*description:/s);
+    expect(content).toContain('Keep total output under 2K chars per batch');
+  });
+
+  it('TEST-070-005: artifact-writer.md has valid dispatch contract with correct output summary format', () => {
+    const content = readFile('commands/discover/artifact-writer.md');
+    expect(content).toContain('DISPATCH CONTRACT');
+    expect(content).toContain('output <= 500 chars');
+    
+    // Verify output format specification
+    expect(content).toMatch(/written:.*list of file paths/);
+    expect(content).toMatch(/format:\s*single\s*\|\s*split/);
+  });
+
+  it('TEST-070-006: SKILL.md dispatch contracts reference all sub-skill files', () => {
+    const content = readFile('commands/discover/SKILL.md');
+    
+    // Verify references to all dispatched sub-skills
+    expect(content).toContain('commands/discover/mode-detection.md');
+    expect(content).toContain('commands/discover/idea-intake.md');
+    expect(content).toContain('commands/discover/ui-taste.md');
+    expect(content).toContain('commands/discover/artifact-writer.md');
+    expect(content).toContain('commands/discover/completeness.md');
+  });
+
+  it('TEST-070-007: error handling protocol defined in dispatch-protocol.md', () => {
+    const content = readFile('commands/discover/dispatch-protocol.md');
+    
+    expect(content).toContain('Error Handling Protocol');
+    expect(content).toContain('Stop');
+    expect(content).toContain('Present error');
+    expect(content).toContain('Retry or fallback');
+    
+    // Verify error categories
+    expect(content).toContain('`error`');
+    expect(content).toContain('`timeout`');
+    expect(content).toContain('`unsupported`');
+  });
+
+  it('TEST-070-008: dedup guard implemented in SKILL.md', () => {
+    const content = readFile('commands/discover/SKILL.md');
+    
+    expect(content).toContain('Dedup Guard');
+    expect(content).toContain('do NOT re-inject');
+    expect(content).not.toMatch(/ARGUMENTS section/i);
+  });
+
+  it('TEST-070-009: all sub-skill files marked as dispatch targets', () => {
+    const subSkills = ['mode-detection.md', 'ui-taste.md', 'artifact-writer.md'];
+    
+    for (const skill of subSkills) {
+      const content = readFile(`commands/discover/${skill}`);
+      expect(content).toContain('(dispatch target)');
+    }
+  });
+
+  it('TEST-070-010: feature spec includes context budget requirements', () => {
+    const requirements = JSON.parse(
+      readFile('specs/features/feat-discover-context-diet/discover/requirements.json')
+    );
+    
+    const req011 = requirements.requirements.find((r: any) => r.id === 'REQ-011');
+    expect(req011).toBeDefined();
+    expect(req011.user_story).toContain('200K chars');
+    
+    const ac1 = req011.acceptance_criteria.find((c: any) => c.id === 'REQ-011-AC-1');
+    expect(ac1).toBeDefined();
+    expect(ac1.ears).toContain('< 200K chars');
+  });
+});

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -105,9 +105,9 @@ describe('Line count limits', () => {
 describe('Sub-skill references', () => {
   // --- discover ---
 
-  it('TEST-053: discover SKILL.md references ui-taste sub-skill via Skill tool', () => {
+  it('TEST-053: discover SKILL.md references ui-taste sub-skill via Skill tool or dispatch contract', () => {
     const content = readFile('commands/discover/SKILL.md');
-    expect(content).toMatch(/Skill.*ui-taste/);
+    expect(content).toMatch(/ui-taste/);
   });
 
   it('TEST-054: discover SKILL.md has DISPATCH CONTRACT block referencing discover_review.json', () => {


### PR DESCRIPTION
Closes #57

## Summary

- Refactor discover skill to use subagent dispatch pattern, reducing main-agent context from **~833K to ~80K chars**
- Enables discover to run on **256K context models** (GPT-4.1, Gemini 2.5 Pro, Claude Sonnet) without triggering auto-compression
- Three-platform compatible: Claude Code (Agent tool), Codex CLI (subagent spawn), OpenCode (Task tool)

### Key changes

- **New `dispatch-protocol.md`**: standard dispatch contract template, context budget (200K target), error handling protocol (retry/fallback), platform-agnostic invocation guide
- **SKILL.md refactored**: dedup guard (no double skill injection), 5 dispatch contracts (mode detection, Layer 1 research, UI taste, Layer 3 generation, artifact writing), compacted from 182→179 lines
- **Sub-skills converted to dispatch targets**: `mode-detection.md` (<500 chars output), `artifact-writer.md` (<500 chars), `ui-taste.md` (<2K per batch) — Stitch MCP JSON never enters main context
- **Test adapted**: TEST-053 updated for dispatch contract architecture

### Context savings breakdown

| Stage | Before | After | Saving |
|-------|--------|-------|--------|
| Skill dedup | 32K | 8K | 24K |
| Mode Detection | 23K | 1K | 22K |
| Layer 1 Research | 18K | 2K | 16K |
| Layer 3 Generation | 24K | 3K | 21K |
| Artifact Writing | 22K | 1K | 21K |
| Stitch UI Taste (3 rounds) | 353K | 10K | 343K |

### Design decisions

- Main agent is a **conversation router** — all heavy computation in subagents
- Subagent gets **full context** (reads all artifact files), main agent gets **bounded summary**
- Fail loud: subagent failure → stop → ask user "retry or fallback?"

## Test plan

- [x] 644/644 tests passing (0 regression)
- [x] 32/32 skill structure e2e tests passing
- [ ] Manual e2e: run `/discover` on a greenfield project with 256K model
- [ ] Manual e2e: run `/discover` on a feature project with Stitch MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)