### PR TITLE
feat: add nopilot benchmark workflow

### DIFF
--- a/benchmark/cases/BUILD-001/case.json
+++ b/benchmark/cases/BUILD-001/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "BUILD-001",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/BUILD-001/fixture/README.md
+++ b/benchmark/cases/BUILD-001/fixture/README.md
@@ -1,0 +1,3 @@
+# BUILD-001
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/BUILD-001/oracle.json
+++ b/benchmark/cases/BUILD-001/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "build",
+    "trace"
+  ]
+}

--- a/benchmark/cases/BUILD-001/prompt.txt
+++ b/benchmark/cases/BUILD-001/prompt.txt
@@ -1,0 +1,1 @@
+Execute the synthetic build benchmark case BUILD-001 under the standard local phase-1 profile.

--- a/benchmark/cases/BUILD-002/case.json
+++ b/benchmark/cases/BUILD-002/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "BUILD-002",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/BUILD-002/fixture/README.md
+++ b/benchmark/cases/BUILD-002/fixture/README.md
@@ -1,0 +1,3 @@
+# BUILD-002
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/BUILD-002/oracle.json
+++ b/benchmark/cases/BUILD-002/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "build",
+    "trace"
+  ]
+}

--- a/benchmark/cases/BUILD-002/prompt.txt
+++ b/benchmark/cases/BUILD-002/prompt.txt
@@ -1,0 +1,1 @@
+Execute the synthetic build benchmark case BUILD-002 under the standard local phase-1 profile.

--- a/benchmark/cases/BUILD-003/case.json
+++ b/benchmark/cases/BUILD-003/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "BUILD-003",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/BUILD-003/fixture/README.md
+++ b/benchmark/cases/BUILD-003/fixture/README.md
@@ -1,0 +1,3 @@
+# BUILD-003
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/BUILD-003/oracle.json
+++ b/benchmark/cases/BUILD-003/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "build",
+    "trace"
+  ]
+}

--- a/benchmark/cases/BUILD-003/prompt.txt
+++ b/benchmark/cases/BUILD-003/prompt.txt
@@ -1,0 +1,1 @@
+Execute the synthetic build benchmark case BUILD-003 under the standard local phase-1 profile.

--- a/benchmark/cases/DISCOVER-001/case.json
+++ b/benchmark/cases/DISCOVER-001/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "DISCOVER-001",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/DISCOVER-001/fixture/README.md
+++ b/benchmark/cases/DISCOVER-001/fixture/README.md
@@ -1,0 +1,3 @@
+# DISCOVER-001
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/DISCOVER-001/oracle.json
+++ b/benchmark/cases/DISCOVER-001/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "contract",
+    "trace"
+  ]
+}

--- a/benchmark/cases/DISCOVER-001/prompt.txt
+++ b/benchmark/cases/DISCOVER-001/prompt.txt
@@ -1,0 +1,1 @@
+Investigate the synthetic benchmark case DISCOVER-001 and report the expected outcome.

--- a/benchmark/cases/DISCOVER-002/case.json
+++ b/benchmark/cases/DISCOVER-002/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "DISCOVER-002",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/DISCOVER-002/fixture/README.md
+++ b/benchmark/cases/DISCOVER-002/fixture/README.md
@@ -1,0 +1,3 @@
+# DISCOVER-002
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/DISCOVER-002/oracle.json
+++ b/benchmark/cases/DISCOVER-002/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "contract",
+    "trace"
+  ]
+}

--- a/benchmark/cases/DISCOVER-002/prompt.txt
+++ b/benchmark/cases/DISCOVER-002/prompt.txt
@@ -1,0 +1,1 @@
+Investigate the synthetic benchmark case DISCOVER-002 and report the expected outcome.

--- a/benchmark/cases/DISCOVER-003/case.json
+++ b/benchmark/cases/DISCOVER-003/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "DISCOVER-003",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/DISCOVER-003/fixture/README.md
+++ b/benchmark/cases/DISCOVER-003/fixture/README.md
@@ -1,0 +1,3 @@
+# DISCOVER-003
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/DISCOVER-003/oracle.json
+++ b/benchmark/cases/DISCOVER-003/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "contract",
+    "trace"
+  ]
+}

--- a/benchmark/cases/DISCOVER-003/prompt.txt
+++ b/benchmark/cases/DISCOVER-003/prompt.txt
@@ -1,0 +1,1 @@
+Investigate the synthetic benchmark case DISCOVER-003 and report the expected outcome.

--- a/benchmark/cases/DISCOVER-004/case.json
+++ b/benchmark/cases/DISCOVER-004/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "DISCOVER-004",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/DISCOVER-004/fixture/README.md
+++ b/benchmark/cases/DISCOVER-004/fixture/README.md
@@ -1,0 +1,3 @@
+# DISCOVER-004
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/DISCOVER-004/oracle.json
+++ b/benchmark/cases/DISCOVER-004/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "contract",
+    "trace"
+  ]
+}

--- a/benchmark/cases/DISCOVER-004/prompt.txt
+++ b/benchmark/cases/DISCOVER-004/prompt.txt
@@ -1,0 +1,1 @@
+Investigate the synthetic benchmark case DISCOVER-004 and report the expected outcome.

--- a/benchmark/cases/DISCOVER-005/case.json
+++ b/benchmark/cases/DISCOVER-005/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "DISCOVER-005",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/DISCOVER-005/fixture/README.md
+++ b/benchmark/cases/DISCOVER-005/fixture/README.md
@@ -1,0 +1,3 @@
+# DISCOVER-005
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/DISCOVER-005/oracle.json
+++ b/benchmark/cases/DISCOVER-005/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "contract",
+    "trace"
+  ]
+}

--- a/benchmark/cases/DISCOVER-005/prompt.txt
+++ b/benchmark/cases/DISCOVER-005/prompt.txt
@@ -1,0 +1,1 @@
+Investigate the synthetic benchmark case DISCOVER-005 and report the expected outcome.

--- a/benchmark/cases/SPEC-001/case.json
+++ b/benchmark/cases/SPEC-001/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "SPEC-001",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/SPEC-001/fixture/README.md
+++ b/benchmark/cases/SPEC-001/fixture/README.md
@@ -1,0 +1,3 @@
+# SPEC-001
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/SPEC-001/oracle.json
+++ b/benchmark/cases/SPEC-001/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "spec",
+    "trace"
+  ]
+}

--- a/benchmark/cases/SPEC-001/prompt.txt
+++ b/benchmark/cases/SPEC-001/prompt.txt
@@ -1,0 +1,1 @@
+Draft the synthetic benchmark outcome for SPEC-001 using the standard local phase-1 profile.

--- a/benchmark/cases/SPEC-002/case.json
+++ b/benchmark/cases/SPEC-002/case.json
@@ -1,0 +1,11 @@
+{
+  "id": "SPEC-002",
+  "case_version": "2026-04-09",
+  "run_profile": "phase1-local-cli-v1",
+  "fixture": "fixture",
+  "budget": {
+    "max_turns": 6,
+    "timeout_seconds": 180,
+    "max_cost_usd": 3
+  }
+}

--- a/benchmark/cases/SPEC-002/fixture/README.md
+++ b/benchmark/cases/SPEC-002/fixture/README.md
@@ -1,0 +1,3 @@
+# SPEC-002
+
+Synthetic fixture copied into a fresh workspace for each local rerun.

--- a/benchmark/cases/SPEC-002/oracle.json
+++ b/benchmark/cases/SPEC-002/oracle.json
@@ -1,0 +1,7 @@
+{
+  "verdict": "pass",
+  "checks": [
+    "spec",
+    "trace"
+  ]
+}

--- a/benchmark/cases/SPEC-002/prompt.txt
+++ b/benchmark/cases/SPEC-002/prompt.txt
@@ -1,0 +1,1 @@
+Draft the synthetic benchmark outcome for SPEC-002 using the standard local phase-1 profile.

--- a/benchmark/suites/phase1.json
+++ b/benchmark/suites/phase1.json
@@ -1,0 +1,26 @@
+{
+  "suite_id": "phase1",
+  "case_ids": [
+    "DISCOVER-001",
+    "DISCOVER-002",
+    "DISCOVER-003",
+    "DISCOVER-004",
+    "DISCOVER-005",
+    "SPEC-001",
+    "SPEC-002",
+    "BUILD-001",
+    "BUILD-002",
+    "BUILD-003"
+  ],
+  "profile_id": "phase1-local-cli-v1",
+  "ranked_platform_ids": [
+    "codex-cli"
+  ],
+  "ranked_platform_admission_rule": "Only platforms with stable complete trace evidence under phase1-local-cli-v1 may be admitted to the official ranked suite.",
+  "platform_admissions": {
+    "codex-cli": {
+      "profile_id": "phase1-local-cli-v1",
+      "stable_full_trace": true
+    }
+  }
+}

--- a/schemas/benchmark-case.schema.json
+++ b/schemas/benchmark-case.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "id",
+    "case_version",
+    "run_profile",
+    "fixture",
+    "budget"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_profile": {
+      "type": "string",
+      "const": "phase1-local-cli-v1"
+    },
+    "fixture": {
+      "type": "string",
+      "const": "fixture"
+    },
+    "budget": {
+      "type": "object",
+      "required": [
+        "max_turns",
+        "timeout_seconds",
+        "max_cost_usd"
+      ],
+      "properties": {
+        "max_turns": {
+          "type": "number",
+          "minimum": 1
+        },
+        "timeout_seconds": {
+          "type": "number",
+          "minimum": 1
+        },
+        "max_cost_usd": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/benchmark-oracle.schema.json
+++ b/schemas/benchmark-oracle.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "verdict"
+  ],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "minLength": 1
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/benchmark-report.schema.json
+++ b/schemas/benchmark-report.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "generated_at",
+    "runs"
+  ],
+  "properties": {
+    "generated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runs": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "summary": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/benchmark-run.schema.json
+++ b/schemas/benchmark-run.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "run_id",
+    "case_id",
+    "case_version",
+    "platform_id",
+    "model_id",
+    "workflow_version",
+    "repo_fixture_hash",
+    "trace_extractor_version",
+    "run_profile"
+  ],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "case_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "platform_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "model_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workflow_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo_fixture_hash": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_extractor_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_profile": {
+      "type": "string",
+      "const": "phase1-local-cli-v1"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/benchmark-trace.schema.json
+++ b/schemas/benchmark-trace.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_id",
+    "observation_events",
+    "semantic_events",
+    "warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observation_events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/observation_event"
+      }
+    },
+    "semantic_events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/semantic_event"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "observation_event": {
+      "type": "object",
+      "required": [
+        "id",
+        "timestamp",
+        "source",
+        "type",
+        "observation_key",
+        "observation_value",
+        "evidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "transcript",
+            "artifact"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "phase_signal",
+            "review_signal",
+            "reverify_signal",
+            "artifact_change"
+          ]
+        },
+        "observation_key": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observation_value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "semantic_event": {
+      "type": "object",
+      "required": [
+        "id",
+        "timestamp",
+        "type",
+        "observation_event_ids",
+        "details"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "phase_entered",
+            "independent_review_dispatched",
+            "fresh_reverification"
+          ]
+        },
+        "observation_event_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/benchmark-verdict.schema.json
+++ b/schemas/benchmark-verdict.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "status"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "needs_review",
+        "pending_review"
+      ]
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/benchmark/adapter-registry.ts
+++ b/src/benchmark/adapter-registry.ts
@@ -1,0 +1,75 @@
+import {
+  createClaudeCodeAdapter,
+} from './adapters/claude-code.js';
+import {
+  createCodexCliAdapter,
+} from './adapters/codex.js';
+import {
+  createOpenCodeAdapter,
+} from './adapters/opencode.js';
+import type { Phase1RunProfile } from './types.js';
+
+export interface AdapterLaunchRequest {
+  platform_id: string;
+  model_id: string;
+  workspace_path: string;
+  prompt_path: string;
+  profile: Phase1RunProfile;
+  timeout_seconds: number;
+}
+
+export interface AdapterRunResult {
+  exit_code: number;
+  transcript_records: Array<Record<string, unknown>>;
+  artifact_snapshot: string[];
+  adapter_notes: string[];
+}
+
+export interface BenchmarkAdapter {
+  platform_id: string;
+  command: string[];
+  run(request: AdapterLaunchRequest): Promise<AdapterRunResult>;
+}
+
+export interface BenchmarkAdapterRegistry {
+  get(platformId: string): BenchmarkAdapter | null;
+  has(platformId: string): boolean;
+  list(): BenchmarkAdapter[];
+}
+
+function getDefaultAdapters(): BenchmarkAdapter[] {
+  return [
+    createClaudeCodeAdapter(),
+    createCodexCliAdapter(),
+    createOpenCodeAdapter(),
+  ];
+}
+
+export function createAdapterRegistry(
+  adapters: BenchmarkAdapter[] = [],
+): BenchmarkAdapterRegistry {
+  const registry = new Map<string, BenchmarkAdapter>();
+
+  for (const adapter of [...getDefaultAdapters(), ...adapters]) {
+    registry.set(adapter.platform_id, adapter);
+  }
+
+  return {
+    get(platformId: string): BenchmarkAdapter | null {
+      return registry.get(platformId) ?? null;
+    },
+    has(platformId: string): boolean {
+      return registry.has(platformId);
+    },
+    list(): BenchmarkAdapter[] {
+      return [...registry.values()];
+    },
+  };
+}
+
+export function getBenchmarkAdapter(
+  platformId: string,
+  registry = createAdapterRegistry(),
+): BenchmarkAdapter | null {
+  return registry.get(platformId);
+}

--- a/src/benchmark/adapter-runner.ts
+++ b/src/benchmark/adapter-runner.ts
@@ -1,0 +1,148 @@
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  createAdapterRegistry,
+  type AdapterLaunchRequest,
+  type AdapterRunResult,
+  type BenchmarkAdapterRegistry,
+} from './adapter-registry.js';
+import { BenchmarkValidationError } from './types.js';
+
+export interface ExecutedAdapterResult extends AdapterRunResult {
+  transcript_path: string;
+  workspace_path: string;
+}
+
+export interface ExecuteRunAdapterOptions {
+  registry?: BenchmarkAdapterRegistry;
+}
+
+function ensureReadableFile(filePath: string, label: string): void {
+  try {
+    accessSync(filePath, constants.R_OK);
+  } catch {
+    throw new BenchmarkValidationError(
+      'incomplete_run_contract',
+      `${label} must exist before adapter execution`,
+      {
+        missingFiles: [path.basename(filePath)],
+      },
+    );
+  }
+}
+
+function collectMissingTraceFields(
+  transcriptRecords: Array<Record<string, unknown>>,
+  requiredFields: string[],
+): string[] {
+  if (transcriptRecords.length === 0) {
+    return [...requiredFields];
+  }
+
+  const missingFields = new Set<string>();
+
+  for (const record of transcriptRecords) {
+    for (const field of requiredFields) {
+      const value = record[field];
+      if (value === null || value === undefined || value === '') {
+        missingFields.add(field);
+      }
+    }
+  }
+
+  return [...missingFields].sort();
+}
+
+function normalizeArtifactSnapshot(
+  workspacePath: string,
+  artifactSnapshot: string[],
+): string[] {
+  return artifactSnapshot.map((entry) => (
+    path.isAbsolute(entry)
+      ? entry
+      : path.resolve(workspacePath, entry)
+  ));
+}
+
+function writeTranscriptStagingFiles(
+  request: AdapterLaunchRequest,
+  transcriptRecords: Array<Record<string, unknown>>,
+): string {
+  const transcriptDir = path.join(request.workspace_path, '.benchmark');
+  mkdirSync(transcriptDir, { recursive: true });
+
+  const transcriptPath = path.join(transcriptDir, `${request.platform_id}-transcript.jsonl`);
+  const transcriptJsonPath = path.join(transcriptDir, `${request.platform_id}-transcript.json`);
+
+  writeFileSync(
+    transcriptPath,
+    transcriptRecords.map((record) => JSON.stringify(record)).join('\n').concat('\n'),
+    'utf-8',
+  );
+  writeFileSync(transcriptJsonPath, `${JSON.stringify(transcriptRecords, null, 2)}\n`, 'utf-8');
+
+  return transcriptPath;
+}
+
+export async function executeRunAdapter(
+  request: AdapterLaunchRequest,
+  options: ExecuteRunAdapterOptions = {},
+): Promise<ExecutedAdapterResult> {
+  ensureReadableFile(request.prompt_path, 'prompt.txt');
+
+  if (!existsSync(request.workspace_path)) {
+    throw new BenchmarkValidationError(
+      'workspace_init_failed',
+      'Benchmark workspace must exist before adapter execution',
+      {
+        missingFiles: [request.workspace_path],
+      },
+    );
+  }
+
+  const registry = options.registry ?? createAdapterRegistry();
+  const adapter = registry.get(request.platform_id);
+
+  if (adapter === null) {
+    throw new BenchmarkValidationError(
+      'adapter_missing',
+      `No benchmark adapter is registered for '${request.platform_id}'`,
+      {
+        missingFields: ['platform_id'],
+      },
+    );
+  }
+
+  const rawResult = await adapter.run(request);
+  const missingTraceFields = collectMissingTraceFields(
+    rawResult.transcript_records,
+    request.profile.transcript_record_fields,
+  );
+
+  if (missingTraceFields.length > 0) {
+    throw new BenchmarkValidationError(
+      'incomplete_run_contract',
+      'Adapter transcript did not satisfy the phase1 transcript profile',
+      {
+        missingTraceFields,
+      },
+    );
+  }
+
+  const transcriptPath = writeTranscriptStagingFiles(request, rawResult.transcript_records);
+
+  return {
+    exit_code: rawResult.exit_code,
+    transcript_path: transcriptPath,
+    workspace_path: request.workspace_path,
+    transcript_records: rawResult.transcript_records.map((record) => ({ ...record })),
+    artifact_snapshot: normalizeArtifactSnapshot(request.workspace_path, rawResult.artifact_snapshot),
+    adapter_notes: [...rawResult.adapter_notes],
+  };
+}

--- a/src/benchmark/adapters/claude-code.ts
+++ b/src/benchmark/adapters/claude-code.ts
@@ -1,0 +1,90 @@
+import {
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import type {
+  AdapterLaunchRequest,
+  AdapterRunResult,
+  BenchmarkAdapter,
+} from '../adapter-registry.js';
+import { BenchmarkValidationError } from '../types.js';
+
+function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectWorkspaceFiles(rootDir, entryPath));
+      continue;
+    }
+
+    files.push(entryPath);
+  }
+
+  return files.sort();
+}
+
+function runClaudeProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
+  const promptText = readFileSync(request.prompt_path, 'utf-8');
+  const args = ['-p', promptText, '--model', request.model_id];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('claude', args, {
+      cwd: request.workspace_path,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new BenchmarkValidationError('process_timeout', 'Claude Code adapter timed out'));
+    }, request.timeout_seconds * 1000);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new BenchmarkValidationError('platform_cli_unavailable', 'Claude Code CLI is not installed'));
+        return;
+      }
+
+      reject(error);
+    });
+    child.on('close', (exitCode) => {
+      clearTimeout(timer);
+      const content = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n');
+      resolve({
+        exit_code: exitCode ?? 1,
+        transcript_records: content.length === 0
+          ? []
+          : [
+              {
+                timestamp: new Date().toISOString(),
+                role: 'assistant',
+                event_type: 'message',
+                content,
+              },
+            ],
+        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        adapter_notes: [`claude ${args.join(' ')}`],
+      });
+    });
+  });
+}
+
+export function createClaudeCodeAdapter(): BenchmarkAdapter {
+  return {
+    platform_id: 'claude-code',
+    command: ['claude'],
+    run: runClaudeProcess,
+  };
+}

--- a/src/benchmark/adapters/claude-code.ts
+++ b/src/benchmark/adapters/claude-code.ts
@@ -1,6 +1,7 @@
 import {
   readdirSync,
   readFileSync,
+  statSync,
 } from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -21,15 +22,26 @@ function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] 
       continue;
     }
 
+    if (path.relative(rootDir, entryPath).startsWith('.benchmark')) {
+      continue;
+    }
+
     files.push(entryPath);
   }
 
   return files.sort();
 }
 
+function buildArtifactSnapshot(rootDir: string, startedAtMs: number): string[] {
+  return collectWorkspaceFiles(rootDir)
+    .filter((entryPath) => statSync(entryPath).mtimeMs >= startedAtMs)
+    .map((entryPath) => path.relative(rootDir, entryPath).replace(/\\/g, '/'));
+}
+
 function runClaudeProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
   const promptText = readFileSync(request.prompt_path, 'utf-8');
   const args = ['-p', promptText, '--model', request.model_id];
+  const startedAtMs = Date.now();
 
   return new Promise((resolve, reject) => {
     const child = spawn('claude', args, {
@@ -74,7 +86,7 @@ function runClaudeProcess(request: AdapterLaunchRequest): Promise<AdapterRunResu
                 content,
               },
             ],
-        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        artifact_snapshot: buildArtifactSnapshot(request.workspace_path, startedAtMs),
         adapter_notes: [`claude ${args.join(' ')}`],
       });
     });

--- a/src/benchmark/adapters/codex.ts
+++ b/src/benchmark/adapters/codex.ts
@@ -1,6 +1,7 @@
 import {
   readdirSync,
   readFileSync,
+  statSync,
 } from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -21,15 +22,26 @@ function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] 
       continue;
     }
 
+    if (path.relative(rootDir, entryPath).startsWith('.benchmark')) {
+      continue;
+    }
+
     files.push(entryPath);
   }
 
   return files.sort();
 }
 
+function buildArtifactSnapshot(rootDir: string, startedAtMs: number): string[] {
+  return collectWorkspaceFiles(rootDir)
+    .filter((entryPath) => statSync(entryPath).mtimeMs >= startedAtMs)
+    .map((entryPath) => path.relative(rootDir, entryPath).replace(/\\/g, '/'));
+}
+
 function runCodexProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
   const promptText = readFileSync(request.prompt_path, 'utf-8');
   const args = ['exec', '--model', request.model_id, promptText];
+  const startedAtMs = Date.now();
 
   return new Promise((resolve, reject) => {
     const child = spawn('codex', args, {
@@ -74,7 +86,7 @@ function runCodexProcess(request: AdapterLaunchRequest): Promise<AdapterRunResul
                 content,
               },
             ],
-        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        artifact_snapshot: buildArtifactSnapshot(request.workspace_path, startedAtMs),
         adapter_notes: [`codex ${args.join(' ')}`],
       });
     });

--- a/src/benchmark/adapters/codex.ts
+++ b/src/benchmark/adapters/codex.ts
@@ -1,0 +1,90 @@
+import {
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import type {
+  AdapterLaunchRequest,
+  AdapterRunResult,
+  BenchmarkAdapter,
+} from '../adapter-registry.js';
+import { BenchmarkValidationError } from '../types.js';
+
+function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectWorkspaceFiles(rootDir, entryPath));
+      continue;
+    }
+
+    files.push(entryPath);
+  }
+
+  return files.sort();
+}
+
+function runCodexProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
+  const promptText = readFileSync(request.prompt_path, 'utf-8');
+  const args = ['exec', '--model', request.model_id, promptText];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('codex', args, {
+      cwd: request.workspace_path,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new BenchmarkValidationError('process_timeout', 'Codex CLI adapter timed out'));
+    }, request.timeout_seconds * 1000);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new BenchmarkValidationError('platform_cli_unavailable', 'Codex CLI is not installed'));
+        return;
+      }
+
+      reject(error);
+    });
+    child.on('close', (exitCode) => {
+      clearTimeout(timer);
+      const content = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n');
+      resolve({
+        exit_code: exitCode ?? 1,
+        transcript_records: content.length === 0
+          ? []
+          : [
+              {
+                timestamp: new Date().toISOString(),
+                role: 'assistant',
+                event_type: 'message',
+                content,
+              },
+            ],
+        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        adapter_notes: [`codex ${args.join(' ')}`],
+      });
+    });
+  });
+}
+
+export function createCodexCliAdapter(): BenchmarkAdapter {
+  return {
+    platform_id: 'codex-cli',
+    command: ['codex'],
+    run: runCodexProcess,
+  };
+}

--- a/src/benchmark/adapters/opencode.ts
+++ b/src/benchmark/adapters/opencode.ts
@@ -1,6 +1,7 @@
 import {
   readdirSync,
   readFileSync,
+  statSync,
 } from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -21,15 +22,26 @@ function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] 
       continue;
     }
 
+    if (path.relative(rootDir, entryPath).startsWith('.benchmark')) {
+      continue;
+    }
+
     files.push(entryPath);
   }
 
   return files.sort();
 }
 
+function buildArtifactSnapshot(rootDir: string, startedAtMs: number): string[] {
+  return collectWorkspaceFiles(rootDir)
+    .filter((entryPath) => statSync(entryPath).mtimeMs >= startedAtMs)
+    .map((entryPath) => path.relative(rootDir, entryPath).replace(/\\/g, '/'));
+}
+
 function runOpenCodeProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
   const promptText = readFileSync(request.prompt_path, 'utf-8');
   const args = ['run', promptText, '--agent', 'coder', '--model', request.model_id];
+  const startedAtMs = Date.now();
 
   return new Promise((resolve, reject) => {
     const child = spawn('opencode', args, {
@@ -74,7 +86,7 @@ function runOpenCodeProcess(request: AdapterLaunchRequest): Promise<AdapterRunRe
                 content,
               },
             ],
-        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        artifact_snapshot: buildArtifactSnapshot(request.workspace_path, startedAtMs),
         adapter_notes: [`opencode ${args.join(' ')}`],
       });
     });

--- a/src/benchmark/adapters/opencode.ts
+++ b/src/benchmark/adapters/opencode.ts
@@ -1,0 +1,90 @@
+import {
+  readdirSync,
+  readFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import type {
+  AdapterLaunchRequest,
+  AdapterRunResult,
+  BenchmarkAdapter,
+} from '../adapter-registry.js';
+import { BenchmarkValidationError } from '../types.js';
+
+function collectWorkspaceFiles(rootDir: string, currentDir = rootDir): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectWorkspaceFiles(rootDir, entryPath));
+      continue;
+    }
+
+    files.push(entryPath);
+  }
+
+  return files.sort();
+}
+
+function runOpenCodeProcess(request: AdapterLaunchRequest): Promise<AdapterRunResult> {
+  const promptText = readFileSync(request.prompt_path, 'utf-8');
+  const args = ['run', promptText, '--agent', 'coder', '--model', request.model_id];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('opencode', args, {
+      cwd: request.workspace_path,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new BenchmarkValidationError('process_timeout', 'OpenCode adapter timed out'));
+    }, request.timeout_seconds * 1000);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        reject(new BenchmarkValidationError('platform_cli_unavailable', 'OpenCode CLI is not installed'));
+        return;
+      }
+
+      reject(error);
+    });
+    child.on('close', (exitCode) => {
+      clearTimeout(timer);
+      const content = [stdout.trim(), stderr.trim()].filter(Boolean).join('\n');
+      resolve({
+        exit_code: exitCode ?? 1,
+        transcript_records: content.length === 0
+          ? []
+          : [
+              {
+                timestamp: new Date().toISOString(),
+                role: 'assistant',
+                event_type: 'message',
+                content,
+              },
+            ],
+        artifact_snapshot: collectWorkspaceFiles(request.workspace_path),
+        adapter_notes: [`opencode ${args.join(' ')}`],
+      });
+    });
+  });
+}
+
+export function createOpenCodeAdapter(): BenchmarkAdapter {
+  return {
+    platform_id: 'opencode',
+    command: ['opencode'],
+    run: runOpenCodeProcess,
+  };
+}

--- a/src/benchmark/case-loader.ts
+++ b/src/benchmark/case-loader.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import path from 'node:path';
+import {
+  BenchmarkValidationError,
+  type BenchmarkCase,
+  type BenchmarkCaseBundle,
+  type BenchmarkOracle,
+} from './types.js';
+import { validateBenchmarkSchema } from './schema-loader.js';
+import { getPhase1RunProfile } from './run-profile.js';
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+}
+
+function tryReadJsonFile(filePath: string): { ok: true; data: unknown } | { ok: false; error: string } {
+  try {
+    return { ok: true, data: readJsonFile(filePath) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function extractMissingRequiredProperties(errors: string[]): string[] {
+  return errors
+    .filter((error) => error.startsWith('missing required property: '))
+    .map((error) => error.replace('missing required property: ', ''))
+    .sort();
+}
+
+function hashFixtureDir(rootDir: string, currentDir = rootDir): string {
+  const hash = createHash('sha256');
+
+  function visit(dir: string): void {
+    const entries = readdirSync(dir, { withFileTypes: true })
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+
+      const relativePath = path.relative(currentDir, fullPath).replace(/\\/g, '/');
+      hash.update(relativePath);
+      hash.update('\n');
+      hash.update(readFileSync(fullPath));
+      hash.update('\n');
+    }
+  }
+
+  visit(rootDir);
+  return hash.digest('hex');
+}
+
+export function loadBenchmarkCase(caseDir: string, _suiteRoot: string | null = null): BenchmarkCaseBundle {
+  const missingFiles: string[] = [];
+  const caseJsonPath = path.join(caseDir, 'case.json');
+  const promptPath = path.join(caseDir, 'prompt.txt');
+  const oraclePath = path.join(caseDir, 'oracle.json');
+  const fixtureDir = path.join(caseDir, 'fixture');
+
+  if (!existsSync(caseJsonPath) || !statSync(caseJsonPath).isFile()) {
+    missingFiles.push('case.json');
+  }
+  if (!existsSync(promptPath) || !statSync(promptPath).isFile()) {
+    missingFiles.push('prompt.txt');
+  }
+  if (!existsSync(oraclePath) || !statSync(oraclePath).isFile()) {
+    missingFiles.push('oracle.json');
+  }
+  if (!existsSync(fixtureDir) || !statSync(fixtureDir).isDirectory()) {
+    missingFiles.push('fixture/');
+  }
+
+  let parsedCase: unknown = {};
+  const caseParseErrors: string[] = [];
+  if (existsSync(caseJsonPath) && statSync(caseJsonPath).isFile()) {
+    const parsed = tryReadJsonFile(caseJsonPath);
+    if (!parsed.ok) {
+      caseParseErrors.push(`case.json: invalid JSON (${parsed.error})`);
+    } else {
+      parsedCase = parsed.data;
+    }
+  }
+
+  const caseValidation = validateBenchmarkSchema<BenchmarkCase>('benchmark-case', parsedCase);
+  const missingFields = caseValidation.valid
+    ? []
+    : extractMissingRequiredProperties(caseValidation.errors);
+
+  if (missingFiles.length > 0) {
+    throw new BenchmarkValidationError(
+      'case_missing_file',
+      'Benchmark case is missing required files',
+      {
+        missingFiles,
+      },
+    );
+  }
+
+  if (caseParseErrors.length > 0 || missingFields.length > 0 || !caseValidation.valid || !caseValidation.data) {
+    throw new BenchmarkValidationError('case_schema_invalid', 'Benchmark case schema validation failed', {
+      missingFields,
+      schemaErrors: [...caseParseErrors, ...caseValidation.errors],
+    });
+  }
+
+  getPhase1RunProfile(caseValidation.data.run_profile);
+
+  const parsedOracle = tryReadJsonFile(oraclePath);
+  if (!parsedOracle.ok) {
+    throw new BenchmarkValidationError('oracle_schema_invalid', 'Benchmark oracle schema validation failed', {
+      schemaErrors: [`oracle.json: invalid JSON (${parsedOracle.error})`],
+    });
+  }
+
+  const oracleValidation = validateBenchmarkSchema<BenchmarkOracle>(
+    'benchmark-oracle',
+    parsedOracle.data,
+  );
+
+  if (!oracleValidation.valid || !oracleValidation.data) {
+    throw new BenchmarkValidationError('oracle_schema_invalid', 'Benchmark oracle schema validation failed', {
+      schemaErrors: oracleValidation.errors,
+    });
+  }
+
+  const promptText = readFileSync(promptPath, 'utf-8');
+  const fixtureHash = hashFixtureDir(fixtureDir);
+
+  return {
+    case: caseValidation.data,
+    oracle: oracleValidation.data,
+    prompt_text: promptText,
+    fixture_dir: fixtureDir,
+    fixture_hash: fixtureHash,
+    run_metadata_seed: {
+      case_id: caseValidation.data.id,
+      case_version: caseValidation.data.case_version,
+      repo_fixture_hash: fixtureHash,
+    },
+  };
+}

--- a/src/benchmark/event-log-writer.ts
+++ b/src/benchmark/event-log-writer.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { SemanticEvent } from './semantic-mapper.js';
+import type { ObservationEvent } from './trace-extractor.js';
+
+export interface BenchmarkTraceLog {
+  schema_version: '1.0.0';
+  run_id: string;
+  observation_events: ObservationEvent[];
+  semantic_events: SemanticEvent[];
+  warnings: string[];
+}
+
+export interface WriteEventLogInput {
+  destination_path: string;
+  run_id: string;
+  observation_events: ObservationEvent[];
+  semantic_events: SemanticEvent[];
+  warnings: string[];
+}
+
+function dedupeWarnings(warnings: string[]): string[] {
+  return [...new Set(warnings)];
+}
+
+export function writeEventLog(input: WriteEventLogInput): BenchmarkTraceLog {
+  const observationIds = new Set(input.observation_events.map((event) => event.id));
+  const warnings = [...input.warnings];
+  const semanticEvents = input.semantic_events.filter((event) => {
+    if (event.observation_event_ids.length === 0) {
+      warnings.push('trace_insufficient');
+      return false;
+    }
+
+    const hasOnlyKnownObservationIds = event.observation_event_ids.every((eventId) => observationIds.has(eventId));
+    if (!hasOnlyKnownObservationIds) {
+      warnings.push('trace_insufficient');
+      return false;
+    }
+
+    return true;
+  });
+
+  const log: BenchmarkTraceLog = {
+    schema_version: '1.0.0',
+    run_id: input.run_id,
+    observation_events: input.observation_events,
+    semantic_events: semanticEvents,
+    warnings: dedupeWarnings(warnings),
+  };
+
+  mkdirSync(path.dirname(input.destination_path), { recursive: true });
+  writeFileSync(input.destination_path, `${JSON.stringify(log, null, 2)}\n`, 'utf-8');
+  return log;
+}

--- a/src/benchmark/failure-taxonomy.ts
+++ b/src/benchmark/failure-taxonomy.ts
@@ -1,0 +1,83 @@
+export const FAILURE_TAG_PRECEDENCE = [
+  'F1',
+  'F2',
+  'F3',
+  'F4',
+  'F5',
+  'F6',
+  'F7',
+  'F8',
+  'F9',
+  'F10',
+  'F11',
+] as const;
+
+export type FailureTag = (typeof FAILURE_TAG_PRECEDENCE)[number];
+
+export interface FailureTagDefinition {
+  key: string;
+}
+
+export const FAILURE_TAG_DEFINITIONS: Record<FailureTag, FailureTagDefinition> = {
+  F1: { key: 'wrong_skill_or_command_route' },
+  F2: { key: 'skipped_required_stage' },
+  F3: { key: 'generation_review_not_separated' },
+  F4: { key: 'missing_fresh_reverify' },
+  F5: { key: 'stage_leakage' },
+  F6: { key: 'missing_prerequisite_input_check' },
+  F7: { key: 'explicit_user_intent_not_honored' },
+  F8: { key: 'parallel_isolation_missing' },
+  F9: { key: 'subagent_completion_not_verified' },
+  F10: { key: 'trace_insufficient' },
+  F11: { key: 'artifact_contract_mismatch' },
+};
+
+export const CORE_PROCESS_FAILURE_TAGS: FailureTag[] = ['F1', 'F2', 'F3', 'F4'];
+
+const FAILURE_TAG_SET = new Set<FailureTag>(FAILURE_TAG_PRECEDENCE);
+const PRECEDENCE_INDEX = new Map<FailureTag, number>(
+  FAILURE_TAG_PRECEDENCE.map((tag, index) => [tag, index]),
+);
+
+export function isFailureTag(value: string): value is FailureTag {
+  return FAILURE_TAG_SET.has(value as FailureTag);
+}
+
+export function isCoreProcessFailureTag(tag: FailureTag): boolean {
+  return CORE_PROCESS_FAILURE_TAGS.includes(tag);
+}
+
+export function normalizeFailureTags(tags: readonly string[]): FailureTag[] {
+  const normalized = new Set<FailureTag>();
+
+  for (const tag of tags) {
+    if (isFailureTag(tag)) {
+      normalized.add(tag);
+    }
+  }
+
+  return [...normalized].sort((left, right) => {
+    return (PRECEDENCE_INDEX.get(left) ?? Number.MAX_SAFE_INTEGER)
+      - (PRECEDENCE_INDEX.get(right) ?? Number.MAX_SAFE_INTEGER);
+  });
+}
+
+export function collectUnknownFailureTags(tags: readonly string[]): string[] {
+  const unknown = new Set<string>();
+
+  for (const tag of tags) {
+    if (!isFailureTag(tag)) {
+      unknown.add(tag);
+    }
+  }
+
+  return [...unknown].sort();
+}
+
+export function selectPrimaryFailureTag(tags: readonly string[]): FailureTag | null {
+  return normalizeFailureTags(tags)[0] ?? null;
+}
+
+export function getFailureTagNames(tags: readonly string[]): string[] {
+  return normalizeFailureTags(tags).map((tag) => FAILURE_TAG_DEFINITIONS[tag].key);
+}

--- a/src/benchmark/fixture-workspace.ts
+++ b/src/benchmark/fixture-workspace.ts
@@ -1,0 +1,43 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  rmSync,
+} from 'node:fs';
+import path from 'node:path';
+import type { BenchmarkCaseBundle } from './types.js';
+
+export interface PreparedRunWorkspace {
+  workspace_path: string;
+  artifact_root: string;
+  cleanup_policy: 'delete_on_success' | 'preserve_on_failure';
+}
+
+function assertSafeRunId(runId: string): void {
+  if (runId.length === 0 || path.isAbsolute(runId) || runId.includes('..') || runId.includes(path.sep)) {
+    throw new Error('invalid_run_id');
+  }
+}
+
+export function prepareRunWorkspace(
+  caseBundle: BenchmarkCaseBundle,
+  runId: string,
+  projectRoot: string,
+): PreparedRunWorkspace {
+  assertSafeRunId(runId);
+  const artifactRoot = path.join(projectRoot, '.benchmark', runId);
+  const workspacePath = path.join(artifactRoot, 'workspace');
+
+  if (existsSync(artifactRoot)) {
+    rmSync(artifactRoot, { recursive: true, force: true });
+  }
+
+  mkdirSync(artifactRoot, { recursive: true });
+  cpSync(caseBundle.fixture_dir, workspacePath, { recursive: true });
+
+  return {
+    workspace_path: workspacePath,
+    artifact_root: artifactRoot,
+    cleanup_policy: 'preserve_on_failure',
+  };
+}

--- a/src/benchmark/oracle-checker.ts
+++ b/src/benchmark/oracle-checker.ts
@@ -1,0 +1,68 @@
+import { normalizeFailureTags, type FailureTag } from './failure-taxonomy.js';
+
+export interface OracleCheckInput {
+  core_process_violations?: string[];
+  failure_tags?: string[];
+  outcome_checks_passed?: boolean;
+  required_events_met?: string[];
+  trace_warnings?: string[];
+  ambiguity_reasons?: string[];
+}
+
+export interface OracleCheckResult {
+  outcome_passed: boolean;
+  required_events_met: string[];
+  failure_tags: FailureTag[];
+  review_reason: string[];
+  trace_insufficient_reasons: string[];
+}
+
+function normalizeStringList(values: readonly string[] | undefined): string[] {
+  const normalized = new Set<string>();
+
+  for (const value of values ?? []) {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      normalized.add(trimmed);
+    }
+  }
+
+  return [...normalized];
+}
+
+function extractTraceInsufficiencyReasons(traceWarnings: readonly string[] | undefined): string[] {
+  const reasons: string[] = [];
+
+  for (const warning of traceWarnings ?? []) {
+    const trimmed = warning.trim();
+    if (!trimmed.startsWith('trace_insufficient')) {
+      continue;
+    }
+
+    const [, reason = 'trace_insufficient'] = trimmed.split(/:\s*/, 2);
+    reasons.push(reason.trim());
+  }
+
+  return normalizeStringList(reasons);
+}
+
+export function checkOracle(input: OracleCheckInput): OracleCheckResult {
+  const traceInsufficientReasons = extractTraceInsufficiencyReasons(input.trace_warnings);
+  const reviewReason = normalizeStringList([
+    ...(traceInsufficientReasons.length > 0 ? ['semantic_ambiguity'] : []),
+    ...normalizeStringList(input.ambiguity_reasons),
+  ]);
+  const failureTags = normalizeFailureTags([
+    ...normalizeStringList(input.core_process_violations),
+    ...normalizeStringList(input.failure_tags),
+    ...(traceInsufficientReasons.length > 0 ? ['F10'] : []),
+  ]);
+
+  return {
+    outcome_passed: input.outcome_checks_passed !== false,
+    required_events_met: normalizeStringList(input.required_events_met),
+    failure_tags: failureTags,
+    review_reason: reviewReason,
+    trace_insufficient_reasons: traceInsufficientReasons,
+  };
+}

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -78,6 +78,34 @@ function takeByWorkflowVersion(
   return runs.splice(index, 1)[0];
 }
 
+function extractExactWorkflowPairs(
+  currentRuns: readonly RegressionComparableRun[],
+  baselineRuns: readonly RegressionComparableRun[],
+): {
+  matched: Array<{ currentRun: RegressionComparableRun; baselineRun: RegressionComparableRun }>;
+  remainingCurrent: RegressionComparableRun[];
+  remainingBaseline: RegressionComparableRun[];
+} {
+  const remainingBaseline = sortRunsForMatching(baselineRuns);
+  const matched: Array<{ currentRun: RegressionComparableRun; baselineRun: RegressionComparableRun }> = [];
+  const remainingCurrent: RegressionComparableRun[] = [];
+
+  for (const currentRun of sortRunsForMatching(currentRuns)) {
+    const baselineRun = takeByWorkflowVersion(remainingBaseline, currentRun.workflow_version);
+    if (baselineRun) {
+      matched.push({ currentRun, baselineRun });
+    } else {
+      remainingCurrent.push(currentRun);
+    }
+  }
+
+  return {
+    matched,
+    remainingCurrent,
+    remainingBaseline,
+  };
+}
+
 function diffFailureTags(current: readonly string[], baseline: readonly string[]): { new_failures: string[]; fixed_failures: string[] } {
   const currentSet = new Set(current);
   const baselineSet = new Set(baseline);
@@ -149,14 +177,34 @@ export function buildRegressionDiff(
   const entries: RegressionDiffEntry[] = [];
 
   for (const comparisonKey of [...comparisonKeys].sort()) {
-    const currentRunsForKey = sortRunsForMatching(currentByKey.get(comparisonKey) ?? []);
-    const baselineRunsForKey = sortRunsForMatching(baselineByKey.get(comparisonKey) ?? []);
+    const exactPairs = extractExactWorkflowPairs(
+      currentByKey.get(comparisonKey) ?? [],
+      baselineByKey.get(comparisonKey) ?? [],
+    );
+    const currentRunsForKey = [...exactPairs.remainingCurrent];
+    const baselineRunsForKey = [...exactPairs.remainingBaseline];
+
+    for (const { currentRun, baselineRun } of exactPairs.matched) {
+      const failureDiff = diffFailureTags(currentRun.failure_tags, baselineRun.failure_tags);
+      entries.push({
+        case_id: currentRun.case_id,
+        comparison_key: comparisonKey,
+        classification: classifyMatchedRun(currentRun, baselineRun),
+        baseline_run_id: baselineRun.run_id,
+        current_run_id: currentRun.run_id,
+        baseline_score: baselineRun.total_score,
+        current_score: currentRun.total_score,
+        score_delta: currentRun.total_score - baselineRun.total_score,
+        status_change: `${baselineRun.status} -> ${currentRun.status}`,
+        new_failures: failureDiff.new_failures,
+        fixed_failures: failureDiff.fixed_failures,
+      });
+    }
 
     while (currentRunsForKey.length > 0 || baselineRunsForKey.length > 0) {
       const currentRun = currentRunsForKey.shift();
       const baselineRun = currentRun
-        ? takeByWorkflowVersion(baselineRunsForKey, currentRun.workflow_version)
-          ?? baselineRunsForKey.shift()
+        ? baselineRunsForKey.shift()
         : baselineRunsForKey.shift();
       const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
 

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -156,7 +156,7 @@ export function buildRegressionDiff(
       const currentRun = currentRunsForKey.shift();
       const baselineRun = currentRun
         ? takeByWorkflowVersion(baselineRunsForKey, currentRun.workflow_version)
-          ?? (baselineRunsForKey.length === 1 ? baselineRunsForKey.shift() : undefined)
+          ?? baselineRunsForKey.shift()
         : baselineRunsForKey.shift();
       const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
 

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -102,8 +102,23 @@ export function buildRegressionDiff(
   currentRuns: readonly RegressionComparableRun[],
   baselineRuns: readonly RegressionComparableRun[],
 ): BenchmarkRegressionDiff {
-  const currentByKey = new Map(currentRuns.map((run) => [buildComparisonKey(run), run]));
-  const baselineByKey = new Map(baselineRuns.map((run) => [buildComparisonKey(run), run]));
+  const currentByKey = new Map<string, RegressionComparableRun[]>();
+  const baselineByKey = new Map<string, RegressionComparableRun[]>();
+
+  for (const run of currentRuns) {
+    const key = buildComparisonKey(run);
+    const bucket = currentByKey.get(key) ?? [];
+    bucket.push(run);
+    currentByKey.set(key, bucket);
+  }
+
+  for (const run of baselineRuns) {
+    const key = buildComparisonKey(run);
+    const bucket = baselineByKey.get(key) ?? [];
+    bucket.push(run);
+    baselineByKey.set(key, bucket);
+  }
+
   const comparisonKeys = new Set<string>([
     ...currentByKey.keys(),
     ...baselineByKey.keys(),
@@ -111,59 +126,65 @@ export function buildRegressionDiff(
   const entries: RegressionDiffEntry[] = [];
 
   for (const comparisonKey of [...comparisonKeys].sort()) {
-    const currentRun = currentByKey.get(comparisonKey);
-    const baselineRun = baselineByKey.get(comparisonKey);
-    const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
+    const currentRunsForKey = [...(currentByKey.get(comparisonKey) ?? [])].sort((left, right) => left.run_id.localeCompare(right.run_id));
+    const baselineRunsForKey = [...(baselineByKey.get(comparisonKey) ?? [])].sort((left, right) => left.run_id.localeCompare(right.run_id));
+    const pairCount = Math.max(currentRunsForKey.length, baselineRunsForKey.length);
 
-    if (currentRun && baselineRun) {
-      const failureDiff = diffFailureTags(currentRun.failure_tags, baselineRun.failure_tags);
-      entries.push({
-        case_id: caseId,
-        comparison_key: comparisonKey,
-        classification: classifyMatchedRun(currentRun, baselineRun),
-        baseline_run_id: baselineRun.run_id,
-        current_run_id: currentRun.run_id,
-        baseline_score: baselineRun.total_score,
-        current_score: currentRun.total_score,
-        score_delta: currentRun.total_score - baselineRun.total_score,
-        status_change: `${baselineRun.status} -> ${currentRun.status}`,
-        new_failures: failureDiff.new_failures,
-        fixed_failures: failureDiff.fixed_failures,
-      });
-      continue;
-    }
+    for (let index = 0; index < pairCount; index += 1) {
+      const currentRun = currentRunsForKey[index];
+      const baselineRun = baselineRunsForKey[index];
+      const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
 
-    if (currentRun) {
-      entries.push({
-        case_id: caseId,
-        comparison_key: comparisonKey,
-        classification: 'added',
-        baseline_run_id: null,
-        current_run_id: currentRun.run_id,
-        baseline_score: null,
-        current_score: currentRun.total_score,
-        score_delta: null,
-        status_change: `missing -> ${currentRun.status}`,
-        new_failures: [...currentRun.failure_tags].sort(),
-        fixed_failures: [],
-      });
-      continue;
-    }
+      if (currentRun && baselineRun) {
+        const failureDiff = diffFailureTags(currentRun.failure_tags, baselineRun.failure_tags);
+        entries.push({
+          case_id: caseId,
+          comparison_key: comparisonKey,
+          classification: classifyMatchedRun(currentRun, baselineRun),
+          baseline_run_id: baselineRun.run_id,
+          current_run_id: currentRun.run_id,
+          baseline_score: baselineRun.total_score,
+          current_score: currentRun.total_score,
+          score_delta: currentRun.total_score - baselineRun.total_score,
+          status_change: `${baselineRun.status} -> ${currentRun.status}`,
+          new_failures: failureDiff.new_failures,
+          fixed_failures: failureDiff.fixed_failures,
+        });
+        continue;
+      }
 
-    if (baselineRun) {
-      entries.push({
-        case_id: caseId,
-        comparison_key: comparisonKey,
-        classification: 'removed',
-        baseline_run_id: baselineRun.run_id,
-        current_run_id: null,
-        baseline_score: baselineRun.total_score,
-        current_score: null,
-        score_delta: null,
-        status_change: `${baselineRun.status} -> missing`,
-        new_failures: [],
-        fixed_failures: [...baselineRun.failure_tags].sort(),
-      });
+      if (currentRun) {
+        entries.push({
+          case_id: caseId,
+          comparison_key: comparisonKey,
+          classification: 'added',
+          baseline_run_id: null,
+          current_run_id: currentRun.run_id,
+          baseline_score: null,
+          current_score: currentRun.total_score,
+          score_delta: null,
+          status_change: `missing -> ${currentRun.status}`,
+          new_failures: [...currentRun.failure_tags].sort(),
+          fixed_failures: [],
+        });
+        continue;
+      }
+
+      if (baselineRun) {
+        entries.push({
+          case_id: caseId,
+          comparison_key: comparisonKey,
+          classification: 'removed',
+          baseline_run_id: baselineRun.run_id,
+          current_run_id: null,
+          baseline_score: baselineRun.total_score,
+          current_score: null,
+          score_delta: null,
+          status_change: `${baselineRun.status} -> missing`,
+          new_failures: [],
+          fixed_failures: [...baselineRun.failure_tags].sort(),
+        });
+      }
     }
   }
 

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -55,6 +55,29 @@ function buildComparisonKey(run: RegressionComparableRun): string {
   return [run.case_id, run.platform_id, run.model_id].join('::');
 }
 
+function sortRunsForMatching(runs: readonly RegressionComparableRun[]): RegressionComparableRun[] {
+  return [...runs].sort((left, right) => {
+    const workflowCompare = left.workflow_version.localeCompare(right.workflow_version);
+    if (workflowCompare !== 0) {
+      return workflowCompare;
+    }
+
+    return left.run_id.localeCompare(right.run_id);
+  });
+}
+
+function takeByWorkflowVersion(
+  runs: RegressionComparableRun[],
+  workflowVersion: string,
+): RegressionComparableRun | undefined {
+  const index = runs.findIndex((run) => run.workflow_version === workflowVersion);
+  if (index === -1) {
+    return undefined;
+  }
+
+  return runs.splice(index, 1)[0];
+}
+
 function diffFailureTags(current: readonly string[], baseline: readonly string[]): { new_failures: string[]; fixed_failures: string[] } {
   const currentSet = new Set(current);
   const baselineSet = new Set(baseline);
@@ -126,27 +149,14 @@ export function buildRegressionDiff(
   const entries: RegressionDiffEntry[] = [];
 
   for (const comparisonKey of [...comparisonKeys].sort()) {
-    const currentRunsForKey = [...(currentByKey.get(comparisonKey) ?? [])].sort((left, right) => {
-      const workflowCompare = left.workflow_version.localeCompare(right.workflow_version);
-      if (workflowCompare !== 0) {
-        return workflowCompare;
-      }
+    const currentRunsForKey = sortRunsForMatching(currentByKey.get(comparisonKey) ?? []);
+    const baselineRunsForKey = sortRunsForMatching(baselineByKey.get(comparisonKey) ?? []);
 
-      return left.run_id.localeCompare(right.run_id);
-    });
-    const baselineRunsForKey = [...(baselineByKey.get(comparisonKey) ?? [])].sort((left, right) => {
-      const workflowCompare = left.workflow_version.localeCompare(right.workflow_version);
-      if (workflowCompare !== 0) {
-        return workflowCompare;
-      }
-
-      return left.run_id.localeCompare(right.run_id);
-    });
-    const pairCount = Math.max(currentRunsForKey.length, baselineRunsForKey.length);
-
-    for (let index = 0; index < pairCount; index += 1) {
-      const currentRun = currentRunsForKey[index];
-      const baselineRun = baselineRunsForKey[index];
+    while (currentRunsForKey.length > 0 || baselineRunsForKey.length > 0) {
+      const currentRun = currentRunsForKey.shift();
+      const baselineRun = currentRun
+        ? takeByWorkflowVersion(baselineRunsForKey, currentRun.workflow_version) ?? baselineRunsForKey.shift()
+        : baselineRunsForKey.shift();
       const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
 
       if (currentRun && baselineRun) {

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -126,8 +126,22 @@ export function buildRegressionDiff(
   const entries: RegressionDiffEntry[] = [];
 
   for (const comparisonKey of [...comparisonKeys].sort()) {
-    const currentRunsForKey = [...(currentByKey.get(comparisonKey) ?? [])].sort((left, right) => left.run_id.localeCompare(right.run_id));
-    const baselineRunsForKey = [...(baselineByKey.get(comparisonKey) ?? [])].sort((left, right) => left.run_id.localeCompare(right.run_id));
+    const currentRunsForKey = [...(currentByKey.get(comparisonKey) ?? [])].sort((left, right) => {
+      const workflowCompare = left.workflow_version.localeCompare(right.workflow_version);
+      if (workflowCompare !== 0) {
+        return workflowCompare;
+      }
+
+      return left.run_id.localeCompare(right.run_id);
+    });
+    const baselineRunsForKey = [...(baselineByKey.get(comparisonKey) ?? [])].sort((left, right) => {
+      const workflowCompare = left.workflow_version.localeCompare(right.workflow_version);
+      if (workflowCompare !== 0) {
+        return workflowCompare;
+      }
+
+      return left.run_id.localeCompare(right.run_id);
+    });
     const pairCount = Math.max(currentRunsForKey.length, baselineRunsForKey.length);
 
     for (let index = 0; index < pairCount; index += 1) {

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -1,0 +1,185 @@
+import type { VerdictStatus } from './verdict-writer.js';
+
+export interface RegressionComparableRun {
+  run_id: string;
+  case_id: string;
+  platform_id: string;
+  model_id: string;
+  workflow_version: string;
+  status: VerdictStatus;
+  total_score: number;
+  failure_tags: string[];
+}
+
+export type RegressionClassification = 'improved' | 'regressed' | 'unchanged' | 'added' | 'removed';
+
+export interface RegressionDiffEntry {
+  case_id: string;
+   comparison_key: string;
+  classification: RegressionClassification;
+  baseline_run_id: string | null;
+  current_run_id: string | null;
+  baseline_score: number | null;
+  current_score: number | null;
+  score_delta: number | null;
+  status_change: string;
+  new_failures: string[];
+  fixed_failures: string[];
+}
+
+export interface RegressionDiffSummary {
+  matched_cases: number;
+  regressions: number;
+  improvements: number;
+  unchanged: number;
+  added_cases: number;
+  removed_cases: number;
+}
+
+export interface BenchmarkRegressionDiff {
+  summary: RegressionDiffSummary;
+  entries: RegressionDiffEntry[];
+}
+
+const STATUS_RANK: Record<VerdictStatus, number> = {
+  fail: 0,
+  needs_review: 1,
+  pass: 2,
+};
+
+function compareStatuses(current: VerdictStatus, baseline: VerdictStatus): number {
+  return STATUS_RANK[current] - STATUS_RANK[baseline];
+}
+
+function buildComparisonKey(run: RegressionComparableRun): string {
+  return [run.case_id, run.platform_id, run.model_id, run.workflow_version].join('::');
+}
+
+function diffFailureTags(current: readonly string[], baseline: readonly string[]): { new_failures: string[]; fixed_failures: string[] } {
+  const currentSet = new Set(current);
+  const baselineSet = new Set(baseline);
+
+  return {
+    new_failures: [...currentSet].filter((tag) => !baselineSet.has(tag)).sort(),
+    fixed_failures: [...baselineSet].filter((tag) => !currentSet.has(tag)).sort(),
+  };
+}
+
+function classifyMatchedRun(
+  currentRun: RegressionComparableRun,
+  baselineRun: RegressionComparableRun,
+): RegressionClassification {
+  const failureDiff = diffFailureTags(currentRun.failure_tags, baselineRun.failure_tags);
+  const statusDelta = compareStatuses(currentRun.status, baselineRun.status);
+  if (statusDelta > 0) {
+    return 'improved';
+  }
+
+  if (statusDelta < 0) {
+    return 'regressed';
+  }
+
+  if (currentRun.total_score > baselineRun.total_score) {
+    return 'improved';
+  }
+
+  if (currentRun.total_score < baselineRun.total_score) {
+    return 'regressed';
+  }
+
+  if (failureDiff.new_failures.length > 0) {
+    return 'regressed';
+  }
+
+  if (failureDiff.fixed_failures.length > 0) {
+    return 'improved';
+  }
+
+  return 'unchanged';
+}
+
+export function buildRegressionDiff(
+  currentRuns: readonly RegressionComparableRun[],
+  baselineRuns: readonly RegressionComparableRun[],
+): BenchmarkRegressionDiff {
+  const currentByKey = new Map(currentRuns.map((run) => [buildComparisonKey(run), run]));
+  const baselineByKey = new Map(baselineRuns.map((run) => [buildComparisonKey(run), run]));
+  const comparisonKeys = new Set<string>([
+    ...currentByKey.keys(),
+    ...baselineByKey.keys(),
+  ]);
+  const entries: RegressionDiffEntry[] = [];
+
+  for (const comparisonKey of [...comparisonKeys].sort()) {
+    const currentRun = currentByKey.get(comparisonKey);
+    const baselineRun = baselineByKey.get(comparisonKey);
+    const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
+
+    if (currentRun && baselineRun) {
+      const failureDiff = diffFailureTags(currentRun.failure_tags, baselineRun.failure_tags);
+      entries.push({
+        case_id: caseId,
+        comparison_key: comparisonKey,
+        classification: classifyMatchedRun(currentRun, baselineRun),
+        baseline_run_id: baselineRun.run_id,
+        current_run_id: currentRun.run_id,
+        baseline_score: baselineRun.total_score,
+        current_score: currentRun.total_score,
+        score_delta: currentRun.total_score - baselineRun.total_score,
+        status_change: `${baselineRun.status} -> ${currentRun.status}`,
+        new_failures: failureDiff.new_failures,
+        fixed_failures: failureDiff.fixed_failures,
+      });
+      continue;
+    }
+
+    if (currentRun) {
+      entries.push({
+        case_id: caseId,
+        comparison_key: comparisonKey,
+        classification: 'added',
+        baseline_run_id: null,
+        current_run_id: currentRun.run_id,
+        baseline_score: null,
+        current_score: currentRun.total_score,
+        score_delta: null,
+        status_change: `missing -> ${currentRun.status}`,
+        new_failures: [...currentRun.failure_tags].sort(),
+        fixed_failures: [],
+      });
+      continue;
+    }
+
+    if (baselineRun) {
+      entries.push({
+        case_id: caseId,
+        comparison_key: comparisonKey,
+        classification: 'removed',
+        baseline_run_id: baselineRun.run_id,
+        current_run_id: null,
+        baseline_score: baselineRun.total_score,
+        current_score: null,
+        score_delta: null,
+        status_change: `${baselineRun.status} -> missing`,
+        new_failures: [],
+        fixed_failures: [...baselineRun.failure_tags].sort(),
+      });
+    }
+  }
+
+  return {
+    summary: {
+      matched_cases: entries.filter((entry) => (
+        entry.classification === 'improved'
+        || entry.classification === 'regressed'
+        || entry.classification === 'unchanged'
+      )).length,
+      regressions: entries.filter((entry) => entry.classification === 'regressed').length,
+      improvements: entries.filter((entry) => entry.classification === 'improved').length,
+      unchanged: entries.filter((entry) => entry.classification === 'unchanged').length,
+      added_cases: entries.filter((entry) => entry.classification === 'added').length,
+      removed_cases: entries.filter((entry) => entry.classification === 'removed').length,
+    },
+    entries,
+  };
+}

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -155,7 +155,8 @@ export function buildRegressionDiff(
     while (currentRunsForKey.length > 0 || baselineRunsForKey.length > 0) {
       const currentRun = currentRunsForKey.shift();
       const baselineRun = currentRun
-        ? takeByWorkflowVersion(baselineRunsForKey, currentRun.workflow_version) ?? baselineRunsForKey.shift()
+        ? takeByWorkflowVersion(baselineRunsForKey, currentRun.workflow_version)
+          ?? (baselineRunsForKey.length === 1 ? baselineRunsForKey.shift() : undefined)
         : baselineRunsForKey.shift();
       const caseId = currentRun?.case_id ?? baselineRun?.case_id ?? 'unknown';
 

--- a/src/benchmark/regression-diff.ts
+++ b/src/benchmark/regression-diff.ts
@@ -52,7 +52,7 @@ function compareStatuses(current: VerdictStatus, baseline: VerdictStatus): numbe
 }
 
 function buildComparisonKey(run: RegressionComparableRun): string {
-  return [run.case_id, run.platform_id, run.model_id, run.workflow_version].join('::');
+  return [run.case_id, run.platform_id, run.model_id].join('::');
 }
 
 function diffFailureTags(current: readonly string[], baseline: readonly string[]): { new_failures: string[]; fixed_failures: string[] } {

--- a/src/benchmark/reporter.ts
+++ b/src/benchmark/reporter.ts
@@ -68,6 +68,36 @@ function readJsonFile<T>(filePath: string): T {
   return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
 }
 
+function normalizeReportVerdict(
+  runId: string,
+  rawVerdict: unknown,
+): {
+  status: VerdictStatus;
+  total_score: number;
+  failure_tags: string[];
+  primary_failure_tag: string | null;
+  human_review_required: boolean;
+} {
+  const rawStatus = (rawVerdict as { status?: string }).status;
+  if (rawStatus === 'pending_review') {
+    throw new Error(`benchmark_report_pending_evaluation: run ${runId} must be evaluated before reporting`);
+  }
+
+  const verdict = rawVerdict as Partial<BenchmarkVerdictArtifact> & { status?: string };
+
+  if (verdict.status !== 'pass' && verdict.status !== 'fail' && verdict.status !== 'needs_review') {
+    throw new Error(`benchmark_report_invalid_verdict: run ${runId} has an unsupported status`);
+  }
+
+  return {
+    status: verdict.status,
+    total_score: typeof verdict.total_score === 'number' ? verdict.total_score : 0,
+    failure_tags: Array.isArray(verdict.failure_tags) ? verdict.failure_tags : [],
+    primary_failure_tag: typeof verdict.primary_failure_tag === 'string' ? verdict.primary_failure_tag : null,
+    human_review_required: verdict.human_review_required === true,
+  };
+}
+
 function loadReportRuns(rootDir: string): BenchmarkReportRun[] {
   const entries = readdirSync(rootDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
@@ -76,10 +106,10 @@ function loadReportRuns(rootDir: string): BenchmarkReportRun[] {
   return entries.map((entry) => {
     const runDir = path.join(rootDir, entry);
     const metadata = readJsonFile<BenchmarkRunMetadata>(path.join(runDir, 'metadata.json'));
-    const verdict = readJsonFile<BenchmarkVerdictArtifact>(path.join(runDir, 'verdict.json'));
-    const failureTags = Array.isArray((verdict as { failure_tags?: unknown }).failure_tags)
-      ? (verdict.failure_tags as string[])
-      : [];
+    const verdict = normalizeReportVerdict(
+      metadata.run_id,
+      readJsonFile<unknown>(path.join(runDir, 'verdict.json')),
+    );
 
     return {
       run_id: metadata.run_id,
@@ -88,10 +118,10 @@ function loadReportRuns(rootDir: string): BenchmarkReportRun[] {
       model_id: metadata.model_id,
       workflow_version: metadata.workflow_version,
       status: verdict.status,
-      total_score: typeof verdict.total_score === 'number' ? verdict.total_score : 0,
-      failure_tags: failureTags,
-      primary_failure_tag: verdict.primary_failure_tag ?? null,
-      human_review_required: verdict.human_review_required ?? false,
+      total_score: verdict.total_score,
+      failure_tags: verdict.failure_tags,
+      primary_failure_tag: verdict.primary_failure_tag,
+      human_review_required: verdict.human_review_required,
     };
   });
 }

--- a/src/benchmark/reporter.ts
+++ b/src/benchmark/reporter.ts
@@ -1,0 +1,229 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { BenchmarkRunMetadata } from './types.js';
+import { buildRegressionDiff, type BenchmarkRegressionDiff } from './regression-diff.js';
+import type { BenchmarkVerdictArtifact, VerdictStatus } from './verdict-writer.js';
+
+export interface BenchmarkReportInput {
+  runs_root: string;
+  baseline_root?: string;
+}
+
+export interface BenchmarkReportRun {
+  run_id: string;
+  case_id: string;
+  platform_id: string;
+  model_id: string;
+  workflow_version: string;
+  status: VerdictStatus;
+  total_score: number;
+  failure_tags: string[];
+  primary_failure_tag: string | null;
+  human_review_required: boolean;
+}
+
+export interface BenchmarkLeaderboardEntry extends BenchmarkReportRun {
+  rank: number;
+}
+
+export interface BenchmarkFailureBreakdown {
+  total_runs: number;
+  status_counts: Record<VerdictStatus, number>;
+  tagged_failures: Array<{
+    tag: string;
+    count: number;
+  }>;
+  untagged_runs: number;
+}
+
+export interface BenchmarkReport {
+  generated_at: string;
+  runs_root: string;
+  baseline_root: string | null;
+  runs: BenchmarkReportRun[];
+  leaderboard: BenchmarkLeaderboardEntry[];
+  failure_breakdown: BenchmarkFailureBreakdown;
+  regression_diff: BenchmarkRegressionDiff;
+  summary: {
+    run_count: number;
+    baseline_run_count: number;
+  };
+}
+
+function buildEmptyRegressionDiff(): BenchmarkRegressionDiff {
+  return {
+    summary: {
+      matched_cases: 0,
+      regressions: 0,
+      improvements: 0,
+      unchanged: 0,
+      added_cases: 0,
+      removed_cases: 0,
+    },
+    entries: [],
+  };
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+}
+
+function loadReportRuns(rootDir: string): BenchmarkReportRun[] {
+  const entries = readdirSync(rootDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  return entries.map((entry) => {
+    const runDir = path.join(rootDir, entry);
+    const metadata = readJsonFile<BenchmarkRunMetadata>(path.join(runDir, 'metadata.json'));
+    const verdict = readJsonFile<BenchmarkVerdictArtifact>(path.join(runDir, 'verdict.json'));
+
+    return {
+      run_id: metadata.run_id,
+        case_id: metadata.case_id,
+        platform_id: metadata.platform_id,
+        model_id: metadata.model_id,
+        workflow_version: metadata.workflow_version,
+        status: verdict.status,
+        total_score: verdict.total_score,
+        failure_tags: verdict.failure_tags,
+      primary_failure_tag: verdict.primary_failure_tag,
+      human_review_required: verdict.human_review_required,
+    };
+  });
+}
+
+function buildLeaderboard(runs: readonly BenchmarkReportRun[]): BenchmarkLeaderboardEntry[] {
+  return [...runs]
+    .sort((left, right) => {
+      if (right.total_score !== left.total_score) {
+        return right.total_score - left.total_score;
+      }
+
+      const caseCompare = left.case_id.localeCompare(right.case_id);
+      if (caseCompare !== 0) {
+        return caseCompare;
+      }
+
+      return left.run_id.localeCompare(right.run_id);
+    })
+    .map((run, index) => ({
+      rank: index + 1,
+      ...run,
+    }));
+}
+
+function buildFailureBreakdown(runs: readonly BenchmarkReportRun[]): BenchmarkFailureBreakdown {
+  const statusCounts: Record<VerdictStatus, number> = {
+    pass: 0,
+    fail: 0,
+    needs_review: 0,
+  };
+  const tagCounts = new Map<string, number>();
+
+  for (const run of runs) {
+    statusCounts[run.status] += 1;
+
+    for (const tag of run.failure_tags) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1);
+    }
+  }
+
+  const taggedFailures = [...tagCounts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+
+      return left.tag.localeCompare(right.tag);
+    });
+
+  return {
+    total_runs: runs.length,
+    status_counts: statusCounts,
+    tagged_failures: taggedFailures,
+    untagged_runs: runs.filter((run) => run.failure_tags.length === 0).length,
+  };
+}
+
+export function buildJsonReport(input: BenchmarkReportInput): BenchmarkReport {
+  const runs = loadReportRuns(input.runs_root);
+  const baselineRuns = input.baseline_root
+    ? loadReportRuns(input.baseline_root)
+    : [];
+
+  return {
+    generated_at: new Date().toISOString(),
+    runs_root: input.runs_root,
+    baseline_root: input.baseline_root ?? null,
+    runs,
+    leaderboard: buildLeaderboard(runs),
+    failure_breakdown: buildFailureBreakdown(runs),
+    regression_diff: input.baseline_root
+      ? buildRegressionDiff(runs, baselineRuns)
+      : buildEmptyRegressionDiff(),
+    summary: {
+      run_count: runs.length,
+      baseline_run_count: baselineRuns.length,
+    },
+  };
+}
+
+export function buildMarkdownReport(report: BenchmarkReport): string {
+  const leaderboardRows = report.leaderboard
+    .map((entry) => `| ${entry.rank} | ${entry.case_id} | ${entry.run_id} | ${entry.platform_id} | ${entry.model_id} | ${entry.workflow_version} | ${entry.status} | ${entry.total_score} |`)
+    .join('\n');
+  const failureRows = report.failure_breakdown.tagged_failures.length > 0
+    ? report.failure_breakdown.tagged_failures
+      .map((entry) => `| ${entry.tag} | ${entry.count} |`)
+      .join('\n')
+    : '| none | 0 |';
+  const regressionRows = report.regression_diff.entries.length > 0
+    ? report.regression_diff.entries
+      .map((entry) => (
+        `| ${entry.case_id} | ${entry.baseline_run_id ?? '-'} | ${entry.current_run_id ?? '-'} | ${entry.score_delta ?? '-'} | ${entry.classification} | ${entry.status_change} |`
+      ))
+      .join('\n')
+    : '| none | - | - | - | unchanged | n/a |';
+
+  return [
+    '# Benchmark Report',
+    '',
+    `Generated At: ${report.generated_at}`,
+    `Current Runs Root: ${report.runs_root}`,
+    `Baseline Root: ${report.baseline_root ?? 'none'}`,
+    '',
+    '## Leaderboard',
+    '',
+    '| Rank | Case | Run | Platform | Model | Workflow | Status | Score |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    leaderboardRows,
+    '',
+    '## Failure Breakdown',
+    '',
+    `Total Runs: ${report.failure_breakdown.total_runs}`,
+    `Status Counts: pass=${report.failure_breakdown.status_counts.pass}, fail=${report.failure_breakdown.status_counts.fail}, needs_review=${report.failure_breakdown.status_counts.needs_review}`,
+    `Untagged Runs: ${report.failure_breakdown.untagged_runs}`,
+    '',
+    '| Failure Tag | Count |',
+    '| --- | --- |',
+    failureRows,
+    '',
+    '## Regression Diff',
+    '',
+    `Matched Cases: ${report.regression_diff.summary.matched_cases}`,
+    `Improvements: ${report.regression_diff.summary.improvements}, Regressions: ${report.regression_diff.summary.regressions}, Unchanged: ${report.regression_diff.summary.unchanged}`,
+    `Added Cases: ${report.regression_diff.summary.added_cases}, Removed Cases: ${report.regression_diff.summary.removed_cases}`,
+    '',
+    '| Case | Baseline Run | Current Run | Score Delta | Classification | Status Change | New Failures | Fixed Failures |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    report.regression_diff.entries.length > 0
+      ? report.regression_diff.entries
+          .map((entry) => (
+            `| ${entry.case_id} | ${entry.baseline_run_id ?? '-'} | ${entry.current_run_id ?? '-'} | ${entry.score_delta ?? '-'} | ${entry.classification} | ${entry.status_change} | ${entry.new_failures.join(', ') || '-'} | ${entry.fixed_failures.join(', ') || '-'} |`
+          ))
+          .join('\n')
+      : '| none | - | - | - | unchanged | n/a | - | - |',
+  ].join('\n');
+}

--- a/src/benchmark/reporter.ts
+++ b/src/benchmark/reporter.ts
@@ -77,18 +77,21 @@ function loadReportRuns(rootDir: string): BenchmarkReportRun[] {
     const runDir = path.join(rootDir, entry);
     const metadata = readJsonFile<BenchmarkRunMetadata>(path.join(runDir, 'metadata.json'));
     const verdict = readJsonFile<BenchmarkVerdictArtifact>(path.join(runDir, 'verdict.json'));
+    const failureTags = Array.isArray((verdict as { failure_tags?: unknown }).failure_tags)
+      ? (verdict.failure_tags as string[])
+      : [];
 
     return {
       run_id: metadata.run_id,
-        case_id: metadata.case_id,
-        platform_id: metadata.platform_id,
-        model_id: metadata.model_id,
-        workflow_version: metadata.workflow_version,
-        status: verdict.status,
-        total_score: verdict.total_score,
-        failure_tags: verdict.failure_tags,
-      primary_failure_tag: verdict.primary_failure_tag,
-      human_review_required: verdict.human_review_required,
+      case_id: metadata.case_id,
+      platform_id: metadata.platform_id,
+      model_id: metadata.model_id,
+      workflow_version: metadata.workflow_version,
+      status: verdict.status,
+      total_score: typeof verdict.total_score === 'number' ? verdict.total_score : 0,
+      failure_tags: failureTags,
+      primary_failure_tag: verdict.primary_failure_tag ?? null,
+      human_review_required: verdict.human_review_required ?? false,
     };
   });
 }

--- a/src/benchmark/review-store.ts
+++ b/src/benchmark/review-store.ts
@@ -1,0 +1,192 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { FailureTag } from './failure-taxonomy.js';
+import type {
+  AutoVerdict,
+  BenchmarkVerdictArtifact,
+  ReviewEvidencePaths,
+  ReviewTicket,
+  VerdictStatus,
+} from './verdict-writer.js';
+
+export interface CreateReviewTicketInput {
+  run_dir: string;
+  review_reason: string[];
+  failure_tags: FailureTag[];
+}
+
+export interface ApplyHumanReviewInput {
+  run_dir: string;
+  final_verdict: 'pass' | 'fail';
+  reviewer?: string;
+  notes?: string;
+}
+
+export interface StoredReviewRecord {
+  status: 'pending_review' | 'resolved';
+  run_dir: string;
+  auto_verdict: AutoVerdict;
+  review_reason: string[];
+  failure_tags: FailureTag[];
+  preserved_evidence: ReviewEvidencePaths;
+  final_verdict: VerdictStatus | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  notes: string | null;
+}
+
+export interface HumanReviewMetadata {
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  notes: string | null;
+}
+
+export type ReviewedBenchmarkVerdictArtifact = BenchmarkVerdictArtifact & {
+  human_review?: HumanReviewMetadata;
+};
+
+export interface ApplyHumanReviewResult {
+  review_record: StoredReviewRecord;
+  verdict: ReviewedBenchmarkVerdictArtifact;
+}
+
+const VERDICT_FILE = 'verdict.json';
+const REVIEW_RECORD_FILE = 'review-record.json';
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function normalizeStringList(values: readonly string[] | undefined): string[] {
+  const normalized = new Set<string>();
+
+  for (const value of values ?? []) {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      normalized.add(trimmed);
+    }
+  }
+
+  return [...normalized];
+}
+
+function loadVerdict(runDir: string): ReviewedBenchmarkVerdictArtifact {
+  return readJsonFile<ReviewedBenchmarkVerdictArtifact>(path.join(runDir, VERDICT_FILE));
+}
+
+function loadReviewRecord(runDir: string): StoredReviewRecord | null {
+  const reviewRecordPath = path.join(runDir, REVIEW_RECORD_FILE);
+  if (!existsSync(reviewRecordPath)) {
+    return null;
+  }
+
+  return readJsonFile<StoredReviewRecord>(reviewRecordPath);
+}
+
+function ensureReviewableVerdict(verdict: BenchmarkVerdictArtifact): ReviewTicket {
+  if (
+    verdict.auto_verdict !== 'needs_review'
+    || !verdict.review_ticket
+    || verdict.review_reason.length === 0
+  ) {
+    throw new Error('benchmark_review_not_required');
+  }
+
+  return verdict.review_ticket;
+}
+
+function ensureReviewRecordPending(reviewRecord: StoredReviewRecord | null): void {
+  if (reviewRecord && reviewRecord.status !== 'pending_review') {
+    throw new Error('review_not_pending');
+  }
+}
+
+function toPendingReviewRecord(
+  runDir: string,
+  verdict: BenchmarkVerdictArtifact,
+  input: CreateReviewTicketInput,
+): StoredReviewRecord {
+  const reviewTicket = ensureReviewableVerdict(verdict);
+
+  return {
+    status: 'pending_review',
+    run_dir: runDir,
+    auto_verdict: verdict.auto_verdict,
+    review_reason: normalizeStringList(
+      input.review_reason.length > 0 ? input.review_reason : verdict.review_reason,
+    ),
+    failure_tags: normalizeStringList(
+      input.failure_tags.length > 0 ? input.failure_tags : verdict.failure_tags,
+    ) as FailureTag[],
+    preserved_evidence: {
+      transcript: reviewTicket.preserved_evidence.transcript,
+      event_log: reviewTicket.preserved_evidence.event_log,
+      artifacts: reviewTicket.preserved_evidence.artifacts,
+    },
+    final_verdict: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    notes: null,
+  };
+}
+
+export function createReviewTicket(input: CreateReviewTicketInput): StoredReviewRecord {
+  const verdict = loadVerdict(input.run_dir);
+  const existingRecord = loadReviewRecord(input.run_dir);
+  ensureReviewRecordPending(existingRecord);
+
+  if (existingRecord && existingRecord.status === 'pending_review') {
+    return existingRecord;
+  }
+
+  const reviewRecord = toPendingReviewRecord(input.run_dir, verdict, input);
+
+  writeJsonFile(path.join(input.run_dir, REVIEW_RECORD_FILE), reviewRecord);
+
+  return reviewRecord;
+}
+
+export function applyHumanReview(input: ApplyHumanReviewInput): ApplyHumanReviewResult {
+  const verdict = loadVerdict(input.run_dir);
+  const existingRecord = loadReviewRecord(input.run_dir);
+  ensureReviewRecordPending(existingRecord);
+  const baseRecord = existingRecord ?? toPendingReviewRecord(input.run_dir, verdict, {
+    run_dir: input.run_dir,
+    review_reason: verdict.review_reason,
+    failure_tags: verdict.failure_tags,
+  });
+  const reviewedAt = new Date().toISOString();
+
+  const reviewRecord: StoredReviewRecord = {
+    ...baseRecord,
+    status: 'resolved',
+    final_verdict: input.final_verdict,
+    reviewed_by: input.reviewer?.trim() || null,
+    reviewed_at: reviewedAt,
+    notes: input.notes?.trim() || null,
+  };
+  const nextVerdict: ReviewedBenchmarkVerdictArtifact = {
+    ...verdict,
+    status: input.final_verdict,
+    human_review_required: false,
+    final_verdict: input.final_verdict,
+    human_review: {
+      reviewed_by: reviewRecord.reviewed_by,
+      reviewed_at: reviewRecord.reviewed_at,
+      notes: reviewRecord.notes,
+    },
+  };
+
+  writeJsonFile(path.join(input.run_dir, REVIEW_RECORD_FILE), reviewRecord);
+  writeJsonFile(path.join(input.run_dir, VERDICT_FILE), nextVerdict);
+
+  return {
+    review_record: reviewRecord,
+    verdict: nextVerdict,
+  };
+}

--- a/src/benchmark/run-profile.ts
+++ b/src/benchmark/run-profile.ts
@@ -1,0 +1,217 @@
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import path from 'node:path';
+import { validateBenchmarkSchema } from './schema-loader.js';
+import type {
+  BenchmarkValidationError,
+  BenchmarkRunMetadata,
+  Phase1RunProfile,
+  RunContractValidationResult,
+} from './types.js';
+
+const PHASE1_PROFILE: Phase1RunProfile = {
+  profile_id: 'phase1-local-cli-v1',
+  required_artifacts: [
+    'metadata.json',
+    'transcript.jsonl',
+    'artifacts',
+    'event-log.json',
+    'verdict.json',
+  ],
+  required_metadata_fields: [
+    'run_id',
+    'case_id',
+    'case_version',
+    'platform_id',
+    'model_id',
+    'workflow_version',
+    'repo_fixture_hash',
+    'trace_extractor_version',
+  ],
+  transcript_record_fields: [
+    'timestamp',
+    'role',
+    'event_type',
+    'content',
+  ],
+};
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+}
+
+function tryReadJsonFile(filePath: string): { ok: true; data: unknown } | { ok: false; error: string } {
+  try {
+    return { ok: true, data: readJsonFile(filePath) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function isMissingValue(value: unknown): boolean {
+  return value === null || value === undefined || value === '';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function collectMissingArtifacts(runDir: string, profile: Phase1RunProfile): string[] {
+  return profile.required_artifacts.filter((artifact) => {
+    const fullPath = path.join(runDir, artifact);
+    if (!existsSync(fullPath)) {
+      return true;
+    }
+
+    if (artifact === 'artifacts') {
+      return !statSync(fullPath).isDirectory();
+    }
+
+    return !statSync(fullPath).isFile();
+  });
+}
+
+function collectMissingTraceFields(
+  transcriptPath: string,
+  requiredFields: string[],
+): string[] {
+  const content = readFileSync(transcriptPath, 'utf-8').trim();
+  if (content.length === 0) {
+    return [...requiredFields];
+  }
+
+  const lines = content.split('\n').filter((line) => line.trim().length > 0);
+  const missing = new Set<string>();
+
+  for (const line of lines) {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(line) as Record<string, unknown>;
+    } catch (error) {
+      throw new Error(`invalid transcript JSON (${error instanceof Error ? error.message : String(error)})`);
+    }
+    for (const field of requiredFields) {
+      if (isMissingValue(parsed[field])) {
+        missing.add(field);
+      }
+    }
+  }
+
+  return [...missing].sort();
+}
+
+export function getPhase1RunProfile(profileId: string): Phase1RunProfile {
+  if (profileId !== PHASE1_PROFILE.profile_id) {
+    throw new Error('unsupported_profile');
+  }
+
+  return {
+    profile_id: PHASE1_PROFILE.profile_id,
+    required_artifacts: [...PHASE1_PROFILE.required_artifacts],
+    required_metadata_fields: [...PHASE1_PROFILE.required_metadata_fields],
+    transcript_record_fields: [...PHASE1_PROFILE.transcript_record_fields],
+  };
+}
+
+export function validateRunContract(
+  runDir: string,
+  profileId: string,
+): RunContractValidationResult {
+  const profile = getPhase1RunProfile(profileId);
+  const missingArtifacts = collectMissingArtifacts(runDir, profile);
+  const errors: string[] = [];
+
+  if (missingArtifacts.length > 0) {
+    errors.push('missing required artifacts');
+    return {
+      valid: false,
+      metadata: null,
+      missing_fields: [],
+      errors,
+      missing_artifacts: missingArtifacts,
+      missing_trace_fields: [],
+    };
+  }
+
+  const metadataPath = path.join(runDir, 'metadata.json');
+  const transcriptPath = path.join(runDir, 'transcript.jsonl');
+  const parsedMetadata = tryReadJsonFile(metadataPath);
+  if (!parsedMetadata.ok) {
+    return {
+      valid: false,
+      metadata: null,
+      missing_fields: [],
+      errors: ['run_schema_invalid'],
+      missing_artifacts: missingArtifacts,
+      missing_trace_fields: [`metadata.json: invalid JSON (${parsedMetadata.error})`],
+    };
+  }
+
+  const rawMetadata = parsedMetadata.data;
+  const metadataValidation = validateBenchmarkSchema<BenchmarkRunMetadata>(
+    'benchmark-run',
+    rawMetadata,
+  );
+  const metadataRecord = asRecord(rawMetadata);
+  if (metadataRecord === null) {
+    errors.push('run_schema_invalid');
+    return {
+      valid: false,
+      metadata: null,
+      missing_fields: [],
+      errors,
+      missing_artifacts: missingArtifacts,
+      missing_trace_fields: [],
+    };
+  }
+  const metadata = metadataValidation.data ?? null;
+  const missingFields = profile.required_metadata_fields.filter((field) => isMissingValue(metadataRecord[field]));
+
+  if (!metadataValidation.valid) {
+    errors.push('run_schema_invalid');
+  }
+
+  if (missingFields.length > 0) {
+    errors.push('missing required metadata fields');
+  }
+
+  const rawRunProfile = metadataRecord['run_profile'];
+  if (!isMissingValue(rawRunProfile) && rawRunProfile !== profile.profile_id) {
+    errors.push('profile_mismatch');
+  }
+
+  let missingTraceFields: string[] = [];
+  try {
+    missingTraceFields = collectMissingTraceFields(
+      transcriptPath,
+      profile.transcript_record_fields,
+    );
+  } catch (error) {
+    errors.push('run_schema_invalid');
+    missingTraceFields = [error instanceof Error ? error.message : String(error)];
+  }
+  if (missingTraceFields.length > 0) {
+    if (!errors.includes('run_schema_invalid')) {
+      errors.push('missing transcript record fields');
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    metadata,
+    missing_fields: [...missingFields],
+    errors,
+    missing_artifacts: missingArtifacts,
+    missing_trace_fields: missingTraceFields,
+  };
+}

--- a/src/benchmark/run-writer.ts
+++ b/src/benchmark/run-writer.ts
@@ -77,11 +77,11 @@ function copyArtifactSnapshot(
     mkdirSync(path.dirname(destinationPath), { recursive: true });
 
     if (statSync(sourcePath).isDirectory()) {
-      cpSync(sourcePath, destinationPath, { recursive: true });
+      cpSync(sourcePath, destinationPath, { recursive: true, preserveTimestamps: true });
       continue;
     }
 
-    cpSync(sourcePath, destinationPath);
+    cpSync(sourcePath, destinationPath, { preserveTimestamps: true });
   }
 }
 

--- a/src/benchmark/run-writer.ts
+++ b/src/benchmark/run-writer.ts
@@ -1,0 +1,164 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { validateRunContract } from './run-profile.js';
+import { BenchmarkValidationError, type BenchmarkRunMetadata } from './types.js';
+import type { ExecutedAdapterResult } from './adapter-runner.js';
+
+export interface StandardRunDirectoryResult {
+  run_dir: string;
+  metadata_path: string;
+  transcript_path: string;
+}
+
+function assertSafeRunId(runId: string): void {
+  if (runId.length === 0 || path.isAbsolute(runId) || runId.includes('..') || runId.includes(path.sep)) {
+    throw new BenchmarkValidationError(
+      'run_write_failed',
+      'run_id must stay within the benchmark output root',
+      {
+        missingFields: ['run_id'],
+      },
+    );
+  }
+}
+
+function resolveArtifactDestinationPath(
+  workspacePath: string,
+  sourcePath: string,
+  artifactsDir: string,
+): string {
+  const relativePath = path.relative(workspacePath, sourcePath);
+  if (
+    relativePath.length === 0
+    || relativePath.startsWith('..')
+    || path.isAbsolute(relativePath)
+  ) {
+    throw new BenchmarkValidationError(
+      'run_write_failed',
+      'Adapter artifact snapshot must reference files within the prepared workspace',
+      {
+        missingFiles: [sourcePath],
+      },
+    );
+  }
+
+  return path.join(artifactsDir, relativePath);
+}
+
+function copyArtifactSnapshot(
+  artifactSnapshot: string[],
+  artifactsDir: string,
+  workspacePath: string,
+): void {
+  for (const sourcePath of artifactSnapshot) {
+    if (!existsSync(sourcePath)) {
+      throw new BenchmarkValidationError(
+        'run_write_failed',
+        'Adapter artifact snapshot referenced a path that does not exist',
+        {
+          missingFiles: [sourcePath],
+        },
+      );
+    }
+
+    const destinationPath = resolveArtifactDestinationPath(
+      workspacePath,
+      sourcePath,
+      artifactsDir,
+    );
+    mkdirSync(path.dirname(destinationPath), { recursive: true });
+
+    if (statSync(sourcePath).isDirectory()) {
+      cpSync(sourcePath, destinationPath, { recursive: true });
+      continue;
+    }
+
+    cpSync(sourcePath, destinationPath);
+  }
+}
+
+function writeTranscriptArtifacts(
+  runDir: string,
+  adapterResult: ExecutedAdapterResult,
+): string {
+  const transcriptPath = path.join(runDir, 'transcript.jsonl');
+  const transcriptJsonPath = path.join(runDir, 'transcript.json');
+  const transcriptJson = adapterResult.transcript_records;
+
+  writeFileSync(transcriptPath, readFileSync(adapterResult.transcript_path, 'utf-8'), 'utf-8');
+  writeFileSync(transcriptJsonPath, `${JSON.stringify(transcriptJson, null, 2)}\n`, 'utf-8');
+
+  return transcriptPath;
+}
+
+export function writeStandardRunDirectory(
+  metadata: BenchmarkRunMetadata,
+  adapterResult: ExecutedAdapterResult,
+  outputRoot: string,
+): StandardRunDirectoryResult {
+  assertSafeRunId(metadata.run_id);
+  const runDir = path.join(outputRoot, metadata.run_id);
+  if (existsSync(runDir)) {
+    rmSync(runDir, { recursive: true, force: true });
+  }
+
+  const artifactsDir = path.join(runDir, 'artifacts');
+  mkdirSync(artifactsDir, { recursive: true });
+
+  const metadataPath = path.join(runDir, 'metadata.json');
+  writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8');
+
+  const transcriptPath = writeTranscriptArtifacts(runDir, adapterResult);
+  copyArtifactSnapshot(
+    adapterResult.artifact_snapshot,
+    artifactsDir,
+    adapterResult.workspace_path,
+  );
+
+  writeFileSync(
+    path.join(runDir, 'event-log.json'),
+    `${JSON.stringify({
+      status: 'pending_trace',
+      observation_events: [],
+      semantic_events: [],
+      warnings: [],
+    }, null, 2)}\n`,
+    'utf-8',
+  );
+  writeFileSync(
+    path.join(runDir, 'verdict.json'),
+    `${JSON.stringify({
+      status: 'pending_review',
+      notes: 'Awaiting trace extraction and evaluation.',
+    }, null, 2)}\n`,
+    'utf-8',
+  );
+
+  const validation = validateRunContract(runDir, metadata.run_profile);
+  if (!validation.valid) {
+    throw new BenchmarkValidationError(
+      'incomplete_run_contract',
+      'Standard run directory did not satisfy the phase1 contract',
+      {
+        missingFields: validation.missing_fields,
+        missingArtifacts: validation.missing_artifacts,
+        missingTraceFields: validation.missing_trace_fields,
+        schemaErrors: validation.errors,
+      },
+    );
+  }
+
+  return {
+    run_dir: runDir,
+    metadata_path: metadataPath,
+    transcript_path: transcriptPath,
+  };
+}

--- a/src/benchmark/schema-loader.ts
+++ b/src/benchmark/schema-loader.ts
@@ -1,0 +1,88 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { SchemaValidationResult } from './types.js';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const Ajv2020 = require('ajv/dist/2020');
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+
+type BenchmarkSchemaName =
+  | 'benchmark-case'
+  | 'benchmark-oracle'
+  | 'benchmark-run'
+  | 'benchmark-verdict'
+  | 'benchmark-report';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCHEMA_DIR = path.resolve(__dirname, '..', '..', 'schemas');
+
+const SCHEMA_FILES: Record<BenchmarkSchemaName, string> = {
+  'benchmark-case': 'benchmark-case.schema.json',
+  'benchmark-oracle': 'benchmark-oracle.schema.json',
+  'benchmark-run': 'benchmark-run.schema.json',
+  'benchmark-verdict': 'benchmark-verdict.schema.json',
+  'benchmark-report': 'benchmark-report.schema.json',
+};
+
+const validatorCache = new Map<BenchmarkSchemaName, ReturnType<typeof ajv.compile>>();
+
+function loadSchema(schemaName: BenchmarkSchemaName): object {
+  const schemaPath = path.join(SCHEMA_DIR, SCHEMA_FILES[schemaName]);
+  return JSON.parse(readFileSync(schemaPath, 'utf-8')) as object;
+}
+
+function getValidator(schemaName: BenchmarkSchemaName): ReturnType<typeof ajv.compile> {
+  const cached = validatorCache.get(schemaName);
+  if (cached) {
+    return cached;
+  }
+
+  const validator = ajv.compile(loadSchema(schemaName));
+  validatorCache.set(schemaName, validator);
+  return validator;
+}
+
+function formatAjvErrors(errors: unknown): string[] {
+  if (!Array.isArray(errors)) {
+    return [];
+  }
+
+  return errors.map((error) => {
+    const typedError = error as {
+      keyword?: string;
+      params?: { missingProperty?: string };
+      message?: string;
+      instancePath?: string;
+    };
+
+    if (typedError.keyword === 'required' && typedError.params?.missingProperty) {
+      return `missing required property: ${typedError.params.missingProperty}`;
+    }
+
+    const instancePath = typedError.instancePath?.replace(/^\//, '') ?? '';
+    if (instancePath.length > 0) {
+      return `${instancePath}: ${typedError.message ?? 'invalid'}`;
+    }
+
+    return typedError.message ?? 'schema validation failed';
+  });
+}
+
+export function validateBenchmarkSchema<T>(
+  schemaName: BenchmarkSchemaName,
+  data: unknown,
+): SchemaValidationResult<T> {
+  const validator = getValidator(schemaName);
+  const valid = validator(data) as boolean;
+
+  return {
+    valid,
+    errors: valid ? [] : formatAjvErrors(validator.errors),
+    data: valid ? (data as T) : undefined,
+  };
+}

--- a/src/benchmark/scorer.ts
+++ b/src/benchmark/scorer.ts
@@ -1,0 +1,67 @@
+import { isCoreProcessFailureTag, normalizeFailureTags } from './failure-taxonomy.js';
+
+export interface ScoreRunInput {
+  process_score: number;
+  outcome_score: number;
+  efficiency_score: number;
+  failure_tags?: string[];
+}
+
+export interface ScoreRunResult {
+  process_score: number;
+  outcome_score: number;
+  efficiency_score: number;
+  counted_efficiency_score: number;
+  total_score: number;
+  efficiency_excluded: boolean;
+  process_score_capped: boolean;
+  process_fail: boolean;
+}
+
+const CORE_PROCESS_SCORE_CAP = 20;
+const PROCESS_FAIL_THRESHOLD = 25;
+const MAX_PROCESS_SCORE = 50;
+const MAX_OUTCOME_SCORE = 30;
+const MAX_EFFICIENCY_SCORE = 20;
+
+function normalizeScore(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, value);
+}
+
+function assertScoreWithinRange(name: string, value: number, max: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > max) {
+    throw new Error(`score_gate_violation: ${name} must be between 0 and ${max}`);
+  }
+}
+
+export function scoreRun(input: ScoreRunInput): ScoreRunResult {
+  assertScoreWithinRange('process_score', input.process_score, MAX_PROCESS_SCORE);
+  assertScoreWithinRange('outcome_score', input.outcome_score, MAX_OUTCOME_SCORE);
+  assertScoreWithinRange('efficiency_score', input.efficiency_score, MAX_EFFICIENCY_SCORE);
+
+  const failureTags = normalizeFailureTags(input.failure_tags ?? []);
+  const hasCoreProcessViolation = failureTags.some((tag) => isCoreProcessFailureTag(tag));
+  const uncappedProcessScore = normalizeScore(input.process_score);
+  const outcomeScore = normalizeScore(input.outcome_score);
+  const efficiencyScore = normalizeScore(input.efficiency_score);
+  const processScore = hasCoreProcessViolation
+    ? Math.min(uncappedProcessScore, CORE_PROCESS_SCORE_CAP)
+    : uncappedProcessScore;
+  const processFail = processScore < PROCESS_FAIL_THRESHOLD;
+  const countedEfficiencyScore = hasCoreProcessViolation || processFail ? 0 : efficiencyScore;
+
+  return {
+    process_score: processScore,
+    outcome_score: outcomeScore,
+    efficiency_score: efficiencyScore,
+    counted_efficiency_score: countedEfficiencyScore,
+    total_score: processScore + outcomeScore + countedEfficiencyScore,
+    efficiency_excluded: countedEfficiencyScore !== efficiencyScore,
+    process_score_capped: processScore !== uncappedProcessScore,
+    process_fail: processFail,
+  };
+}

--- a/src/benchmark/semantic-mapper.ts
+++ b/src/benchmark/semantic-mapper.ts
@@ -65,6 +65,7 @@ export function deriveSemanticEvents(
   }
 
   if (!reviewObservation) {
+    pushWarning(warnings, 'trace_insufficient');
     return { semantic_events: semanticEvents, warnings };
   }
 

--- a/src/benchmark/semantic-mapper.ts
+++ b/src/benchmark/semantic-mapper.ts
@@ -1,0 +1,104 @@
+import type { ObservationEvent } from './trace-extractor.js';
+
+export type SemanticEventType =
+  | 'phase_entered'
+  | 'independent_review_dispatched'
+  | 'fresh_reverification';
+
+export interface SemanticEvent {
+  id: string;
+  timestamp: string;
+  type: SemanticEventType;
+  observation_event_ids: string[];
+  details: Record<string, string>;
+}
+
+export interface SemanticMappingResult {
+  semantic_events: SemanticEvent[];
+  warnings: string[];
+}
+
+function formatSemanticId(index: number): string {
+  return `sem-${String(index).padStart(4, '0')}`;
+}
+
+function pushWarning(warnings: string[], warning: string): void {
+  if (!warnings.includes(warning)) {
+    warnings.push(warning);
+  }
+}
+
+export function deriveSemanticEvents(
+  observationEvents: ObservationEvent[],
+): SemanticMappingResult {
+  const semanticEvents: SemanticEvent[] = [];
+  const warnings: string[] = [];
+
+  const phaseObservation = observationEvents.find(
+    (event) => event.type === 'phase_signal' && event.observation_key === 'phase_candidate',
+  );
+  if (phaseObservation) {
+    semanticEvents.push({
+      id: formatSemanticId(semanticEvents.length + 1),
+      timestamp: phaseObservation.timestamp,
+      type: 'phase_entered',
+      observation_event_ids: [phaseObservation.id],
+      details: {
+        phase: phaseObservation.observation_value,
+      },
+    });
+  }
+
+  const reviewObservation = observationEvents.find(
+    (event) => event.type === 'review_signal' && event.observation_key === 'review_dispatch_candidate',
+  );
+  if (reviewObservation) {
+    semanticEvents.push({
+      id: formatSemanticId(semanticEvents.length + 1),
+      timestamp: reviewObservation.timestamp,
+      type: 'independent_review_dispatched',
+      observation_event_ids: [reviewObservation.id],
+      details: {
+        reviewer: reviewObservation.observation_value,
+      },
+    });
+  }
+
+  if (!reviewObservation) {
+    return { semantic_events: semanticEvents, warnings };
+  }
+
+  const reverifyObservation = observationEvents.find(
+    (event) =>
+      event.type === 'reverify_signal'
+      && event.observation_key === 'reverify_candidate'
+      && event.timestamp >= reviewObservation.timestamp,
+  );
+  const artifactObservation = observationEvents.find(
+    (event) =>
+      event.type === 'artifact_change'
+      && event.timestamp >= reviewObservation.timestamp
+      && (!reverifyObservation || event.timestamp >= reverifyObservation.timestamp),
+  );
+
+  if (!reverifyObservation || !artifactObservation) {
+    pushWarning(warnings, 'trace_insufficient');
+    return { semantic_events: semanticEvents, warnings };
+  }
+
+  semanticEvents.push({
+    id: formatSemanticId(semanticEvents.length + 1),
+    timestamp: reverifyObservation.timestamp,
+    type: 'fresh_reverification',
+    observation_event_ids: [
+      reviewObservation.id,
+      reverifyObservation.id,
+      artifactObservation.id,
+    ],
+    details: {
+      tool: reverifyObservation.observation_value,
+    },
+  });
+
+  return { semantic_events: semanticEvents, warnings };
+}

--- a/src/benchmark/suite-manifest.ts
+++ b/src/benchmark/suite-manifest.ts
@@ -1,0 +1,279 @@
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadBenchmarkCase } from './case-loader.js';
+import { getPhase1RunProfile } from './run-profile.js';
+
+const MINIMUM_PHASE1_CASE_COUNT = 10;
+
+interface PlatformAdmission {
+  profile_id: string;
+  stable_full_trace: boolean;
+}
+
+interface RawSuiteManifest {
+  suite_id?: unknown;
+  case_ids?: unknown;
+  profile_id?: unknown;
+  ranked_platform_ids?: unknown;
+  ranked_platform_admission_rule?: unknown;
+  platform_admissions?: unknown;
+}
+
+export interface Phase1SuiteManifest {
+  suite_id: string;
+  case_ids: string[];
+  minimum_case_count: number;
+  profile_id: 'phase1-local-cli-v1';
+  ranked_platform_ids: string[];
+  ranked_platform_admission_rule: string;
+}
+
+export class SuiteManifestError extends Error {
+  code: string;
+  details: Record<string, unknown>;
+
+  constructor(code: string, message: string, details: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'SuiteManifestError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_BENCHMARK_ROOT = path.resolve(__dirname, '..', '..', 'benchmark');
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.length > 0);
+}
+
+function asAdmissions(value: unknown): Record<string, PlatformAdmission> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  const admissions: Record<string, PlatformAdmission> = {};
+
+  for (const [platformId, entry] of Object.entries(value)) {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      continue;
+    }
+
+    const profileId = entry['profile_id'];
+    const stableFullTrace = entry['stable_full_trace'];
+    if (typeof profileId !== 'string' || typeof stableFullTrace !== 'boolean') {
+      continue;
+    }
+
+    admissions[platformId] = {
+      profile_id: profileId,
+      stable_full_trace: stableFullTrace,
+    };
+  }
+
+  return admissions;
+}
+
+function getSuiteManifestPath(suiteId: string, benchmarkRoot: string): string {
+  return path.join(benchmarkRoot, 'suites', `${suiteId}.json`);
+}
+
+function assertPathExistsAsDirectory(dirPath: string): void {
+  if (!existsSync(dirPath) || !statSync(dirPath).isDirectory()) {
+    throw new SuiteManifestError('case_selector_unknown', 'Benchmark case selector did not resolve to a case directory', {
+      selector: dirPath,
+    });
+  }
+}
+
+function validateCaseDir(caseDir: string): string {
+  assertPathExistsAsDirectory(caseDir);
+  loadBenchmarkCase(caseDir);
+  return caseDir;
+}
+
+function isPathInsideRoot(targetPath: string, rootPath: string): boolean {
+  const relativePath = path.relative(rootPath, targetPath);
+  return relativePath.length === 0 || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function looksLikePathSelector(selector: string): boolean {
+  return path.isAbsolute(selector)
+    || selector.startsWith('.')
+    || selector.includes('/')
+    || selector.includes('\\');
+}
+
+function normalizeManifest(
+  suiteId: string,
+  rawManifest: RawSuiteManifest,
+): Phase1SuiteManifest & { platform_admissions: Record<string, PlatformAdmission> } {
+  if (rawManifest.suite_id !== suiteId) {
+    throw new SuiteManifestError('suite_not_found', 'Benchmark suite manifest did not match the requested suite id', {
+      suite_id: suiteId,
+    });
+  }
+
+  if (!isStringArray(rawManifest.case_ids)) {
+    throw new SuiteManifestError('suite_invalid', 'Benchmark suite manifest is missing case ids', {
+      suite_id: suiteId,
+    });
+  }
+
+  if (rawManifest.case_ids.length < MINIMUM_PHASE1_CASE_COUNT) {
+    throw new SuiteManifestError(
+      'suite_under_minimum',
+      'Official phase1 benchmark suite must include at least ten synthetic cases',
+      {
+        suite_id: suiteId,
+        minimum_case_count: MINIMUM_PHASE1_CASE_COUNT,
+        actual_case_count: rawManifest.case_ids.length,
+      },
+    );
+  }
+
+  if (typeof rawManifest.profile_id !== 'string') {
+    throw new SuiteManifestError('suite_profile_mismatch', 'Benchmark suite manifest is missing a supported run profile', {
+      suite_id: suiteId,
+    });
+  }
+
+  let profileId: 'phase1-local-cli-v1';
+  try {
+    profileId = getPhase1RunProfile(rawManifest.profile_id).profile_id;
+  } catch {
+    throw new SuiteManifestError('suite_profile_mismatch', 'Benchmark suite manifest must use phase1-local-cli-v1', {
+      suite_id: suiteId,
+      profile_id: rawManifest.profile_id,
+    });
+  }
+
+  if (!isStringArray(rawManifest.ranked_platform_ids)) {
+    throw new SuiteManifestError(
+      'ranked_platform_missing_admission',
+      'Ranked phase1 platforms must declare full-trace admission',
+      {
+        suite_id: suiteId,
+      },
+    );
+  }
+
+  if (typeof rawManifest.ranked_platform_admission_rule !== 'string' || rawManifest.ranked_platform_admission_rule.length === 0) {
+    throw new SuiteManifestError(
+      'ranked_platform_missing_admission',
+      'Ranked phase1 platforms must declare the admission rule',
+      {
+        suite_id: suiteId,
+      },
+    );
+  }
+
+  const platformAdmissions = asAdmissions(rawManifest.platform_admissions);
+  const missingAdmissions = rawManifest.ranked_platform_ids.filter((platformId) => {
+    const admission = platformAdmissions[platformId];
+    return !admission
+      || admission.profile_id !== profileId
+      || admission.stable_full_trace !== true;
+  });
+
+  if (missingAdmissions.length > 0) {
+    throw new SuiteManifestError(
+      'ranked_platform_missing_admission',
+      'Ranked phase1 platforms must satisfy the stable full-trace admission rule',
+      {
+        suite_id: suiteId,
+        platform_ids: missingAdmissions,
+      },
+    );
+  }
+
+  return {
+    suite_id: suiteId,
+    case_ids: [...rawManifest.case_ids],
+    minimum_case_count: MINIMUM_PHASE1_CASE_COUNT,
+    profile_id: profileId,
+    ranked_platform_ids: [...rawManifest.ranked_platform_ids],
+    ranked_platform_admission_rule: rawManifest.ranked_platform_admission_rule,
+    platform_admissions: platformAdmissions,
+  };
+}
+
+export function loadSuiteManifest(
+  suiteId: string,
+  benchmarkRoot = DEFAULT_BENCHMARK_ROOT,
+): Phase1SuiteManifest {
+  const manifestPath = getSuiteManifestPath(suiteId, benchmarkRoot);
+  if (!existsSync(manifestPath) || !statSync(manifestPath).isFile()) {
+    throw new SuiteManifestError('suite_not_found', 'Benchmark suite manifest was not found', {
+      suite_id: suiteId,
+    });
+  }
+
+  const manifest = normalizeManifest(
+    suiteId,
+    readJsonFile(manifestPath) as RawSuiteManifest,
+  );
+
+  for (const caseId of manifest.case_ids) {
+    validateCaseDir(path.join(benchmarkRoot, 'cases', caseId));
+  }
+
+  return {
+    suite_id: manifest.suite_id,
+    case_ids: manifest.case_ids,
+    minimum_case_count: manifest.minimum_case_count,
+    profile_id: manifest.profile_id,
+    ranked_platform_ids: manifest.ranked_platform_ids,
+    ranked_platform_admission_rule: manifest.ranked_platform_admission_rule,
+  };
+}
+
+export function resolveCaseSelector(selector: string, suiteRoot: string): string[] {
+  const benchmarkRoot = path.resolve(suiteRoot);
+
+  if (looksLikePathSelector(selector)) {
+    const resolvedCaseDir = path.isAbsolute(selector)
+      ? path.resolve(selector)
+      : path.resolve(benchmarkRoot, selector);
+
+    if (!isPathInsideRoot(resolvedCaseDir, benchmarkRoot)) {
+      throw new SuiteManifestError(
+        'case_path_outside_suite_root',
+        'Explicit benchmark case paths must stay inside the benchmark suite root',
+        {
+          selector,
+          suite_root: benchmarkRoot,
+        },
+      );
+    }
+
+    return [validateCaseDir(resolvedCaseDir)];
+  }
+
+  const suiteManifestPath = getSuiteManifestPath(selector, benchmarkRoot);
+  if (existsSync(suiteManifestPath) && statSync(suiteManifestPath).isFile()) {
+    return loadSuiteManifest(selector, benchmarkRoot).case_ids.map((caseId) => (
+      validateCaseDir(path.join(benchmarkRoot, 'cases', caseId))
+    ));
+  }
+
+  const caseDir = path.join(benchmarkRoot, 'cases', selector);
+  if (existsSync(caseDir) && statSync(caseDir).isDirectory()) {
+    return [validateCaseDir(caseDir)];
+  }
+
+  throw new SuiteManifestError('case_selector_unknown', 'Benchmark case selector was not recognized', {
+    selector,
+    suite_root: benchmarkRoot,
+  });
+}

--- a/src/benchmark/trace-extractor.ts
+++ b/src/benchmark/trace-extractor.ts
@@ -1,0 +1,188 @@
+export interface BenchmarkTranscriptRecord {
+  timestamp: string;
+  role: string;
+  event_type: string;
+  content: string;
+  tool_name?: string;
+  [key: string]: unknown;
+}
+
+export interface BenchmarkArtifactChange {
+  timestamp: string;
+  path: string;
+  change_type: 'added' | 'modified' | 'deleted';
+  [key: string]: unknown;
+}
+
+export type ObservationSource = 'transcript' | 'artifact';
+
+export type ObservationType =
+  | 'phase_signal'
+  | 'review_signal'
+  | 'reverify_signal'
+  | 'artifact_change';
+
+export interface ObservationEvent {
+  id: string;
+  timestamp: string;
+  source: ObservationSource;
+  type: ObservationType;
+  observation_key: string;
+  observation_value: string;
+  evidence: {
+    content?: string;
+    transcript_index?: number;
+    tool_name?: string;
+    artifact_path?: string;
+    change_type?: BenchmarkArtifactChange['change_type'];
+  };
+}
+
+export interface ExtractObservationEventsInput {
+  transcript?: BenchmarkTranscriptRecord[];
+  artifact_changes?: BenchmarkArtifactChange[];
+}
+
+function formatObservationId(index: number): string {
+  return `obs-${String(index).padStart(4, '0')}`;
+}
+
+function parsePhaseCandidate(content: string): string | null {
+  const phaseMatch = content.match(/\b(?:entering|entered|starting|start)\s+([a-z0-9_-]+)\s+phase\b/i);
+  if (phaseMatch) {
+    return phaseMatch[1].toLowerCase();
+  }
+
+  return null;
+}
+
+function parseReviewDispatchCandidate(
+  content: string,
+  toolName: string | undefined,
+): string | null {
+  const normalizedContent = content.toLowerCase();
+  if (!normalizedContent.includes('independent')) {
+    return null;
+  }
+
+  if (!/\b(dispatch|dispatching|sent|launched)\b/.test(normalizedContent)) {
+    return null;
+  }
+
+  if (toolName && toolName.trim().length > 0) {
+    return toolName.trim();
+  }
+
+  if (normalizedContent.includes('critic')) {
+    return 'critic';
+  }
+
+  if (normalizedContent.includes('review')) {
+    return 'review';
+  }
+
+  return null;
+}
+
+function parseReverifyCandidate(
+  content: string,
+  toolName: string | undefined,
+): string | null {
+  const normalizedContent = content.toLowerCase();
+  const mentionsReverify =
+    normalizedContent.includes('re-ran')
+    || normalizedContent.includes('reran')
+    || normalizedContent.includes('reverify')
+    || normalizedContent.includes('reverification');
+
+  if (!mentionsReverify) {
+    return null;
+  }
+
+  if (toolName && toolName.trim().length > 0) {
+    return toolName.trim();
+  }
+
+  const inlineToolMatch = content.match(/\b(npm test|npm run \S+|pnpm test|yarn test)\b/i);
+  if (inlineToolMatch) {
+    return inlineToolMatch[1];
+  }
+
+  return 'unknown';
+}
+
+export function extractObservationEvents(
+  input: ExtractObservationEventsInput,
+): ObservationEvent[] {
+  const observationEvents: ObservationEvent[] = [];
+
+  for (const [index, record] of (input.transcript ?? []).entries()) {
+    const phaseCandidate = parsePhaseCandidate(record.content);
+    if (phaseCandidate) {
+      observationEvents.push({
+        id: formatObservationId(observationEvents.length + 1),
+        timestamp: record.timestamp,
+        source: 'transcript',
+        type: 'phase_signal',
+        observation_key: 'phase_candidate',
+        observation_value: phaseCandidate,
+        evidence: {
+          content: record.content,
+          transcript_index: index,
+          tool_name: record.tool_name,
+        },
+      });
+    }
+
+    const reviewCandidate = parseReviewDispatchCandidate(record.content, record.tool_name);
+    if (reviewCandidate) {
+      observationEvents.push({
+        id: formatObservationId(observationEvents.length + 1),
+        timestamp: record.timestamp,
+        source: 'transcript',
+        type: 'review_signal',
+        observation_key: 'review_dispatch_candidate',
+        observation_value: reviewCandidate,
+        evidence: {
+          content: record.content,
+          transcript_index: index,
+          tool_name: record.tool_name,
+        },
+      });
+    }
+
+    const reverifyCandidate = parseReverifyCandidate(record.content, record.tool_name);
+    if (reverifyCandidate) {
+      observationEvents.push({
+        id: formatObservationId(observationEvents.length + 1),
+        timestamp: record.timestamp,
+        source: 'transcript',
+        type: 'reverify_signal',
+        observation_key: 'reverify_candidate',
+        observation_value: reverifyCandidate,
+        evidence: {
+          content: record.content,
+          transcript_index: index,
+          tool_name: record.tool_name,
+        },
+      });
+    }
+  }
+
+  for (const artifactChange of input.artifact_changes ?? []) {
+    observationEvents.push({
+      id: formatObservationId(observationEvents.length + 1),
+      timestamp: artifactChange.timestamp,
+      source: 'artifact',
+      type: 'artifact_change',
+      observation_key: `artifact_${artifactChange.change_type}`,
+      observation_value: artifactChange.path,
+      evidence: {
+        artifact_path: artifactChange.path,
+        change_type: artifactChange.change_type,
+      },
+    });
+  }
+
+  return observationEvents;
+}

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -1,0 +1,88 @@
+export interface BenchmarkBudget {
+  max_turns: number;
+  timeout_seconds: number;
+  max_cost_usd: number;
+  [key: string]: unknown;
+}
+
+export interface BenchmarkCase {
+  id: string;
+  case_version: string;
+  run_profile: string;
+  fixture: string;
+  budget: BenchmarkBudget;
+  [key: string]: unknown;
+}
+
+export interface BenchmarkOracle {
+  verdict: string;
+  checks?: string[];
+  [key: string]: unknown;
+}
+
+export interface BenchmarkRunMetadata {
+  run_id: string;
+  case_id: string;
+  case_version: string;
+  platform_id: string;
+  model_id: string;
+  workflow_version: string;
+  repo_fixture_hash: string;
+  trace_extractor_version: string;
+  run_profile: string;
+  [key: string]: unknown;
+}
+
+export interface BenchmarkCaseBundle {
+  case: BenchmarkCase;
+  oracle: BenchmarkOracle;
+  prompt_text: string;
+  fixture_dir: string;
+  fixture_hash: string;
+  run_metadata_seed: Pick<
+    BenchmarkRunMetadata,
+    'case_id' | 'case_version' | 'repo_fixture_hash'
+  >;
+}
+
+export interface Phase1RunProfile {
+  profile_id: 'phase1-local-cli-v1';
+  required_artifacts: string[];
+  required_metadata_fields: string[];
+  transcript_record_fields: string[];
+}
+
+export interface BenchmarkValidationDetails {
+  missingFiles?: string[];
+  missingFields?: string[];
+  missingArtifacts?: string[];
+  missingTraceFields?: string[];
+  schemaErrors?: string[];
+}
+
+export class BenchmarkValidationError extends Error {
+  code: string;
+  details: BenchmarkValidationDetails;
+
+  constructor(code: string, message: string, details: BenchmarkValidationDetails = {}) {
+    super(message);
+    this.name = 'BenchmarkValidationError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export interface SchemaValidationResult<T> {
+  valid: boolean;
+  errors: string[];
+  data?: T;
+}
+
+export interface RunContractValidationResult {
+  valid: boolean;
+  metadata: BenchmarkRunMetadata | null;
+  missing_fields: string[];
+  errors: string[];
+  missing_artifacts: string[];
+  missing_trace_fields: string[];
+}

--- a/src/benchmark/types.ts
+++ b/src/benchmark/types.ts
@@ -30,6 +30,7 @@ export interface BenchmarkRunMetadata {
   repo_fixture_hash: string;
   trace_extractor_version: string;
   run_profile: string;
+  adapter_exit_code?: number;
   [key: string]: unknown;
 }
 

--- a/src/benchmark/verdict-writer.ts
+++ b/src/benchmark/verdict-writer.ts
@@ -1,0 +1,187 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { checkOracle, type OracleCheckInput } from './oracle-checker.js';
+import {
+  collectUnknownFailureTags,
+  getFailureTagNames,
+  normalizeFailureTags,
+  selectPrimaryFailureTag,
+  type FailureTag,
+} from './failure-taxonomy.js';
+import { validateBenchmarkSchema } from './schema-loader.js';
+import { scoreRun, type ScoreRunInput, type ScoreRunResult } from './scorer.js';
+
+export type VerdictStatus = 'pass' | 'fail' | 'needs_review';
+export type AutoVerdict = 'pass' | 'fail' | 'process_fail' | 'needs_review';
+
+export interface ReviewEvidencePaths {
+  transcript: string;
+  event_log: string;
+  artifacts: string;
+}
+
+export interface ReviewTicket {
+  status: 'pending_review';
+  run_dir: string;
+  review_reason: string[];
+  failure_tags: FailureTag[];
+  preserved_evidence: ReviewEvidencePaths;
+}
+
+export interface ComposeVerdictInput {
+  run_id: string;
+  oracle_result: OracleCheckInput;
+  run_metrics: ScoreRunInput;
+  evidence_paths?: ReviewEvidencePaths;
+}
+
+export interface BenchmarkVerdictArtifact {
+  status: VerdictStatus;
+  auto_verdict: AutoVerdict;
+  run_id: string;
+  total_score: number;
+  score_breakdown: ScoreRunResult;
+  failure_tags: FailureTag[];
+  failure_tag_names: string[];
+  primary_failure_tag: FailureTag | null;
+  human_review_required: boolean;
+  final_verdict: VerdictStatus | null;
+  review_reason: string[];
+  required_events_met: string[];
+  trace_insufficient_reasons: string[];
+  review_ticket?: ReviewTicket;
+}
+
+function ensureFailureTags(
+  failureTags: FailureTag[],
+  outcomePassed: boolean,
+  processFail: boolean,
+): FailureTag[] {
+  if ((processFail || !outcomePassed) && failureTags.length === 0) {
+    return ['F11'];
+  }
+
+  return failureTags;
+}
+
+function ensureReviewEvidence(evidencePaths: ReviewEvidencePaths | undefined): ReviewEvidencePaths {
+  if (!evidencePaths) {
+    throw new Error('benchmark_review_evidence_missing: transcript, event_log, and artifacts are required');
+  }
+
+  if (!evidencePaths.transcript || !evidencePaths.event_log || !evidencePaths.artifacts) {
+    throw new Error('benchmark_review_evidence_missing: transcript, event_log, and artifacts are required');
+  }
+
+  return {
+    transcript: evidencePaths.transcript,
+    event_log: evidencePaths.event_log,
+    artifacts: evidencePaths.artifacts,
+  };
+}
+
+function determineAutoVerdict(
+  reviewReason: string[],
+  score: ScoreRunResult,
+  failureTags: FailureTag[],
+  outcomePassed: boolean,
+): AutoVerdict {
+  if (reviewReason.length > 0) {
+    return 'needs_review';
+  }
+
+  if (score.process_fail) {
+    return 'process_fail';
+  }
+
+  if (failureTags.length > 0 || !outcomePassed) {
+    return 'fail';
+  }
+
+  return 'pass';
+}
+
+function toVerdictStatus(autoVerdict: AutoVerdict): VerdictStatus {
+  if (autoVerdict === 'pass') {
+    return 'pass';
+  }
+
+  if (autoVerdict === 'needs_review') {
+    return 'needs_review';
+  }
+
+  return 'fail';
+}
+
+export function composeVerdict(input: ComposeVerdictInput): BenchmarkVerdictArtifact {
+  const rawFailureTags = [
+    ...(input.oracle_result.core_process_violations ?? []),
+    ...(input.oracle_result.failure_tags ?? []),
+  ];
+  const unknownFailureTags = collectUnknownFailureTags(rawFailureTags);
+  if (unknownFailureTags.length > 0) {
+    throw new Error(`unknown_failure_tag: ${unknownFailureTags.join(', ')}`);
+  }
+
+  const oracleCheck = checkOracle(input.oracle_result);
+  const score = scoreRun({
+    ...input.run_metrics,
+    failure_tags: oracleCheck.failure_tags,
+  });
+  const reviewReason = [...oracleCheck.review_reason];
+  const failureTags = ensureFailureTags(
+    normalizeFailureTags([
+      ...oracleCheck.failure_tags,
+      ...(reviewReason.length > 0 ? ['F10'] : []),
+    ]),
+    oracleCheck.outcome_passed,
+    score.process_fail,
+  );
+  const autoVerdict = determineAutoVerdict(
+    reviewReason,
+    score,
+    failureTags,
+    oracleCheck.outcome_passed,
+  );
+  const reviewTicket = reviewReason.length > 0
+    ? {
+        status: 'pending_review' as const,
+        run_dir: input.run_id,
+        review_reason: reviewReason,
+        failure_tags: failureTags,
+        preserved_evidence: ensureReviewEvidence(input.evidence_paths),
+      }
+    : undefined;
+
+  return {
+    status: toVerdictStatus(autoVerdict),
+    auto_verdict: autoVerdict,
+    run_id: input.run_id,
+    total_score: score.total_score,
+    score_breakdown: score,
+    failure_tags: failureTags,
+    failure_tag_names: getFailureTagNames(failureTags),
+    primary_failure_tag: selectPrimaryFailureTag(failureTags),
+    human_review_required: reviewReason.length > 0,
+    final_verdict: null,
+    review_reason: reviewReason,
+    required_events_met: oracleCheck.required_events_met,
+    trace_insufficient_reasons: oracleCheck.trace_insufficient_reasons,
+    review_ticket: reviewTicket,
+  };
+}
+
+export function writeVerdictArtifact(
+  destinationPath: string,
+  verdict: BenchmarkVerdictArtifact,
+): BenchmarkVerdictArtifact {
+  const validation = validateBenchmarkSchema('benchmark-verdict', verdict);
+  if (!validation.valid) {
+    throw new Error(`benchmark_verdict_invalid: ${validation.errors.join('; ')}`);
+  }
+
+  mkdirSync(path.dirname(destinationPath), { recursive: true });
+  writeFileSync(destinationPath, `${JSON.stringify(verdict, null, 2)}\n`, 'utf-8');
+
+  return verdict;
+}

--- a/src/nopilot-cli.ts
+++ b/src/nopilot-cli.ts
@@ -366,7 +366,6 @@ benchmark
         });
         const semanticResult = deriveSemanticEvents(observationEvents);
         const requiredEventsMet = mapRequiredEvents(semanticResult.semantic_events);
-        const oracleCheck = evaluateOracleChecks(oracle, runDir, requiredEventsMet);
         const traceLog = writeEventLog({
           destination_path: join(runDir, 'event-log.json'),
           run_id: metadata.run_id,
@@ -374,6 +373,7 @@ benchmark
           semantic_events: semanticResult.semantic_events,
           warnings: semanticResult.warnings,
         });
+        const oracleCheck = evaluateOracleChecks(oracle, runDir, requiredEventsMet, traceLog.warnings);
         const verdict = composeVerdict({
           run_id: metadata.run_id,
           oracle_result: {
@@ -390,13 +390,42 @@ benchmark
             artifacts: 'artifacts',
           },
         });
+        const reviewRecordPath = join(runDir, 'review-record.json');
+        if (verdict.human_review_required && existsSync(reviewRecordPath)) {
+          const reviewRecord = readJsonFile<{ status?: string }>(reviewRecordPath);
+          if (reviewRecord.status === 'resolved') {
+            const preservedVerdict = readJsonFile<{
+              status: string;
+              auto_verdict: string;
+              total_score: number;
+              review_reason: string[];
+            }>(join(runDir, 'verdict.json'));
+            runs.push({
+              run_id: metadata.run_id,
+              case_id: metadata.case_id,
+              status: preservedVerdict.status,
+              auto_verdict: preservedVerdict.auto_verdict,
+              total_score: preservedVerdict.total_score,
+              review_reason: preservedVerdict.review_reason,
+              warnings: traceLog.warnings,
+            });
+            continue;
+          }
+        }
+
         const writtenVerdict = writeVerdictArtifact(join(runDir, 'verdict.json'), verdict);
         if (writtenVerdict.human_review_required) {
-          createReviewTicket({
-            run_dir: runDir,
-            review_reason: writtenVerdict.review_reason,
-            failure_tags: writtenVerdict.failure_tags,
-          });
+          try {
+            createReviewTicket({
+              run_dir: runDir,
+              review_reason: writtenVerdict.review_reason,
+              failure_tags: writtenVerdict.failure_tags,
+            });
+          } catch (error) {
+            if (!(error instanceof Error) || error.message !== 'review_not_pending') {
+              throw error;
+            }
+          }
         }
 
         runs.push({
@@ -572,7 +601,6 @@ function collectArtifactChanges(artifactsRoot: string): BenchmarkArtifactChange[
   }
 
   const changes: BenchmarkArtifactChange[] = [];
-  const timestamp = new Date().toISOString();
 
   const visit = (dirPath: string): void => {
     for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
@@ -583,7 +611,7 @@ function collectArtifactChanges(artifactsRoot: string): BenchmarkArtifactChange[
       }
 
       changes.push({
-        timestamp,
+        timestamp: statSync(entryPath).mtime.toISOString(),
         path: relative(artifactsRoot, entryPath).replace(/\\/g, '/'),
         change_type: 'added',
       });
@@ -612,6 +640,7 @@ function evaluateOracleChecks(
   oracle: BenchmarkOracle,
   runDir: string,
   requiredEventsMet: string[],
+  traceWarnings: string[],
 ): {
   outcome_checks_passed: boolean;
   failure_tags: string[];
@@ -627,7 +656,7 @@ function evaluateOracleChecks(
       continue;
     }
 
-    if (normalizedCheck === 'build') {
+    if (normalizedCheck === 'build' || normalizedCheck === 'contract') {
       const hasBuildArtifact = existsSync(join(runDir, 'artifacts', 'logs', 'result.json'));
       if (!hasBuildArtifact) {
         outcomeChecksPassed = false;
@@ -636,10 +665,17 @@ function evaluateOracleChecks(
       continue;
     }
 
-    if (normalizedCheck === 'tests') {
+    if (normalizedCheck === 'trace') {
+      if (traceWarnings.length > 0) {
+        ambiguityReasons.push('oracle_trace_check_unverifiable');
+      }
+      continue;
+    }
+
+    if (normalizedCheck === 'tests' || normalizedCheck === 'spec') {
       const hasFreshReverify = requiredEventsMet.some((event) => event.startsWith('fresh_reverification:'));
       if (!hasFreshReverify) {
-        ambiguityReasons.push('oracle_tests_check_unverifiable');
+        ambiguityReasons.push(`oracle_${normalizedCheck}_check_unverifiable`);
       }
       continue;
     }

--- a/src/nopilot-cli.ts
+++ b/src/nopilot-cli.ts
@@ -715,6 +715,10 @@ function evaluateOracleChecks(
       if (!hasSpecArtifact) {
         ambiguityReasons.push('oracle_spec_check_unverifiable');
       }
+      const hasFreshReverify = requiredEventsMet.some((event) => event.startsWith('fresh_reverification:'));
+      if (!hasFreshReverify) {
+        ambiguityReasons.push('oracle_spec_check_unverifiable');
+      }
       continue;
     }
 
@@ -725,10 +729,10 @@ function evaluateOracleChecks(
       continue;
     }
 
-    if (normalizedCheck === 'tests' || normalizedCheck === 'spec') {
+    if (normalizedCheck === 'tests') {
       const hasFreshReverify = requiredEventsMet.some((event) => event.startsWith('fresh_reverification:'));
       if (!hasFreshReverify) {
-        ambiguityReasons.push(`oracle_${normalizedCheck}_check_unverifiable`);
+        ambiguityReasons.push('oracle_tests_check_unverifiable');
       }
       continue;
     }

--- a/src/nopilot-cli.ts
+++ b/src/nopilot-cli.ts
@@ -36,7 +36,7 @@ import { loadBenchmarkCase } from './benchmark/case-loader.js';
 import { writeEventLog } from './benchmark/event-log-writer.js';
 import { prepareRunWorkspace } from './benchmark/fixture-workspace.js';
 import { buildJsonReport, buildMarkdownReport } from './benchmark/reporter.js';
-import { getPhase1RunProfile } from './benchmark/run-profile.js';
+import { getPhase1RunProfile, validateRunContract } from './benchmark/run-profile.js';
 import { writeStandardRunDirectory } from './benchmark/run-writer.js';
 import { deriveSemanticEvents } from './benchmark/semantic-mapper.js';
 import { resolveCaseSelector } from './benchmark/suite-manifest.js';
@@ -359,6 +359,30 @@ benchmark
         const metadata = readJsonFile<BenchmarkRunMetadata>(join(runDir, 'metadata.json'));
         const oraclePath = join(benchmarkRoot, 'cases', metadata.case_id, 'oracle.json');
         const oracle = readJsonFile<BenchmarkOracle>(oraclePath);
+        const reviewRecordPath = join(runDir, 'review-record.json');
+        if (existsSync(reviewRecordPath)) {
+          const reviewRecord = readJsonFile<{ status?: string }>(reviewRecordPath);
+          if (reviewRecord.status === 'resolved') {
+            const preservedVerdict = readJsonFile<{
+              status: string;
+              auto_verdict: string;
+              total_score: number;
+              review_reason: string[];
+            }>(join(runDir, 'verdict.json'));
+
+            runs.push({
+              run_id: metadata.run_id,
+              case_id: metadata.case_id,
+              status: preservedVerdict.status,
+              auto_verdict: preservedVerdict.auto_verdict,
+              total_score: preservedVerdict.total_score,
+              review_reason: preservedVerdict.review_reason,
+              warnings: [],
+            });
+            continue;
+          }
+        }
+
         const transcript = readTranscriptRecords(runDir);
         const observationEvents = extractObservationEvents({
           transcript,
@@ -390,29 +414,6 @@ benchmark
             artifacts: 'artifacts',
           },
         });
-        const reviewRecordPath = join(runDir, 'review-record.json');
-        if (verdict.human_review_required && existsSync(reviewRecordPath)) {
-          const reviewRecord = readJsonFile<{ status?: string }>(reviewRecordPath);
-          if (reviewRecord.status === 'resolved') {
-            const preservedVerdict = readJsonFile<{
-              status: string;
-              auto_verdict: string;
-              total_score: number;
-              review_reason: string[];
-            }>(join(runDir, 'verdict.json'));
-            runs.push({
-              run_id: metadata.run_id,
-              case_id: metadata.case_id,
-              status: preservedVerdict.status,
-              auto_verdict: preservedVerdict.auto_verdict,
-              total_score: preservedVerdict.total_score,
-              review_reason: preservedVerdict.review_reason,
-              warnings: traceLog.warnings,
-            });
-            continue;
-          }
-        }
-
         const writtenVerdict = writeVerdictArtifact(join(runDir, 'verdict.json'), verdict);
         if (writtenVerdict.human_review_required) {
           try {
@@ -656,11 +657,29 @@ function evaluateOracleChecks(
       continue;
     }
 
-    if (normalizedCheck === 'build' || normalizedCheck === 'contract') {
+    if (normalizedCheck === 'contract') {
+      const contractValidation = validateRunContract(runDir, 'phase1-local-cli-v1');
+      if (!contractValidation.valid) {
+        outcomeChecksPassed = false;
+        failureTags.push('F11');
+      }
+      continue;
+    }
+
+    if (normalizedCheck === 'build') {
       const hasBuildArtifact = existsSync(join(runDir, 'artifacts', 'logs', 'result.json'));
       if (!hasBuildArtifact) {
         outcomeChecksPassed = false;
         failureTags.push('F11');
+      }
+      continue;
+    }
+
+    if (normalizedCheck === 'spec') {
+      const hasSpecArtifact = existsSync(join(runDir, 'artifacts', 'spec.json'))
+        || existsSync(join(runDir, 'artifacts', 'spec', 'index.json'));
+      if (!hasSpecArtifact) {
+        ambiguityReasons.push('oracle_spec_check_unverifiable');
       }
       continue;
     }

--- a/src/nopilot-cli.ts
+++ b/src/nopilot-cli.ts
@@ -12,10 +12,12 @@ import { Command } from 'commander';
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, resolve, join } from 'node:path';
+import { dirname, resolve, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 
@@ -27,6 +29,20 @@ import {
   MIGRATION_SINCE_VERSION,
 } from './skill-engine/legacy-migrator.js';
 import { getActivePlatforms, getPlatform } from './skill-engine/platform-registry.js';
+import { createReviewTicket, applyHumanReview } from './benchmark/review-store.js';
+import { createAdapterRegistry } from './benchmark/adapter-registry.js';
+import { executeRunAdapter } from './benchmark/adapter-runner.js';
+import { loadBenchmarkCase } from './benchmark/case-loader.js';
+import { writeEventLog } from './benchmark/event-log-writer.js';
+import { prepareRunWorkspace } from './benchmark/fixture-workspace.js';
+import { buildJsonReport, buildMarkdownReport } from './benchmark/reporter.js';
+import { getPhase1RunProfile } from './benchmark/run-profile.js';
+import { writeStandardRunDirectory } from './benchmark/run-writer.js';
+import { deriveSemanticEvents } from './benchmark/semantic-mapper.js';
+import { resolveCaseSelector } from './benchmark/suite-manifest.js';
+import { extractObservationEvents, type BenchmarkArtifactChange, type BenchmarkTranscriptRecord } from './benchmark/trace-extractor.js';
+import { composeVerdict, writeVerdictArtifact } from './benchmark/verdict-writer.js';
+import type { BenchmarkRunMetadata, BenchmarkValidationError, BenchmarkOracle } from './benchmark/types.js';
 
 // CLI output helpers (AGENTS.md: 禁止在源文件中直接 console.log)
 function out(message: string): void { process.stdout.write(message + '\n'); }
@@ -36,6 +52,8 @@ function err(message: string): void { process.stderr.write(message + '\n'); }
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PACKAGE_ROOT = resolve(__dirname, '..');
+const DEFAULT_BENCHMARK_ROOT = resolve(PACKAGE_ROOT, 'benchmark');
+const DEFAULT_TRACE_EXTRACTOR_VERSION = 'benchmark-trace-v1';
 
 const LASH_DIRECTIVE_MARKER = '## Lash (Auto-triggered Multi-Agent Build Orchestrator)';
 
@@ -218,7 +236,251 @@ program
     process.exit(0);
   });
 
-program.parse(process.argv);
+// ─── benchmark ──────────────────────────────────────────────────────────────
+
+const benchmark = program
+  .command('benchmark')
+  .description('Run local benchmark validation, execution, evaluation, reporting, and review workflows');
+
+benchmark
+  .command('validate-case <selector>')
+  .description('Validate one benchmark case, a suite id, or a selector within the benchmark root')
+  .option('--benchmark-root <path>', 'path to the benchmark root', DEFAULT_BENCHMARK_ROOT)
+  .action(async (selector: string, options: { benchmarkRoot: string }) => {
+    await runBenchmarkCommand(() => {
+      const benchmarkRoot = resolve(options.benchmarkRoot);
+      const caseDirs = resolveCaseSelector(selector, benchmarkRoot);
+      const cases = caseDirs.map((caseDir) => {
+        const bundle = loadBenchmarkCase(caseDir, benchmarkRoot);
+        return {
+          case_id: bundle.case.id,
+          case_version: bundle.case.case_version,
+          run_profile: bundle.case.run_profile,
+          fixture_hash: bundle.fixture_hash,
+          case_dir: caseDir,
+        };
+      });
+
+      return {
+        command_group: 'benchmark',
+        subcommand: 'validate-case',
+        cases,
+      };
+    });
+  });
+
+benchmark
+  .command('run <selector>')
+  .description('Launch one or more benchmark cases through a local CLI adapter')
+  .option('--benchmark-root <path>', 'path to the benchmark root', DEFAULT_BENCHMARK_ROOT)
+  .option('--output-root <path>', 'directory for benchmark run outputs', join(process.cwd(), '.nopilot', 'benchmark', 'runs'))
+  .option('--platform <platformId>', 'adapter platform id', 'codex-cli')
+  .option('--model <modelId>', 'model id forwarded to the adapter', 'gpt-5.4')
+  .option('--workflow-version <value>', 'workflow version stored in run metadata', `nopilot-cli-v${getVersion()}`)
+  .action(async (
+    selector: string,
+    options: {
+      benchmarkRoot: string;
+      outputRoot: string;
+      platform: string;
+      model: string;
+      workflowVersion: string;
+    },
+  ) => {
+    await runBenchmarkCommand(async () => {
+      const benchmarkRoot = resolve(options.benchmarkRoot);
+      const outputRoot = resolve(options.outputRoot);
+      const caseDirs = resolveCaseSelector(selector, benchmarkRoot);
+      const registry = createAdapterRegistry();
+      const runs = [];
+
+      for (const [index, caseDir] of caseDirs.entries()) {
+        const bundle = loadBenchmarkCase(caseDir, benchmarkRoot);
+        const profile = getPhase1RunProfile(bundle.case.run_profile);
+        const runId = formatRunId(bundle.case.id, index);
+        const workspace = prepareRunWorkspace(bundle, runId, process.cwd());
+        const adapterResult = await executeRunAdapter(
+          {
+            platform_id: options.platform,
+            model_id: options.model,
+            workspace_path: workspace.workspace_path,
+            prompt_path: join(caseDir, 'prompt.txt'),
+            profile,
+            timeout_seconds: bundle.case.budget.timeout_seconds,
+          },
+          { registry },
+        );
+        const metadata: BenchmarkRunMetadata = {
+          run_id: runId,
+          case_id: bundle.case.id,
+          case_version: bundle.case.case_version,
+          platform_id: options.platform,
+          model_id: options.model,
+          workflow_version: options.workflowVersion,
+          repo_fixture_hash: bundle.fixture_hash,
+          trace_extractor_version: DEFAULT_TRACE_EXTRACTOR_VERSION,
+          run_profile: profile.profile_id,
+        };
+        const runOutput = writeStandardRunDirectory(metadata, adapterResult, outputRoot);
+
+        runs.push({
+          run_id: runId,
+          case_id: bundle.case.id,
+          case_version: bundle.case.case_version,
+          run_dir: runOutput.run_dir,
+          metadata_path: runOutput.metadata_path,
+          transcript_path: runOutput.transcript_path,
+          repo_fixture_hash: bundle.fixture_hash,
+        });
+      }
+
+      return {
+        command_group: 'benchmark',
+        subcommand: 'run',
+        output_root: outputRoot,
+        platform_id: options.platform,
+        model_id: options.model,
+        runs,
+      };
+    });
+  });
+
+benchmark
+  .command('evaluate <runPath>')
+  .description('Extract trace events and compose verdicts for one run directory or a runs root')
+  .option('--benchmark-root <path>', 'path to the benchmark root', DEFAULT_BENCHMARK_ROOT)
+  .action(async (runPath: string, options: { benchmarkRoot: string }) => {
+    await runBenchmarkCommand(async () => {
+      const benchmarkRoot = resolve(options.benchmarkRoot);
+      const runDirs = resolveRunDirectories(runPath);
+      const runs = [];
+
+      for (const runDir of runDirs) {
+        const metadata = readJsonFile<BenchmarkRunMetadata>(join(runDir, 'metadata.json'));
+        const oraclePath = join(benchmarkRoot, 'cases', metadata.case_id, 'oracle.json');
+        const oracle = readJsonFile<BenchmarkOracle>(oraclePath);
+        const transcript = readTranscriptRecords(runDir);
+        const observationEvents = extractObservationEvents({
+          transcript,
+          artifact_changes: collectArtifactChanges(join(runDir, 'artifacts')),
+        });
+        const semanticResult = deriveSemanticEvents(observationEvents);
+        const requiredEventsMet = mapRequiredEvents(semanticResult.semantic_events);
+        const oracleCheck = evaluateOracleChecks(oracle, runDir, requiredEventsMet);
+        const traceLog = writeEventLog({
+          destination_path: join(runDir, 'event-log.json'),
+          run_id: metadata.run_id,
+          observation_events: observationEvents,
+          semantic_events: semanticResult.semantic_events,
+          warnings: semanticResult.warnings,
+        });
+        const verdict = composeVerdict({
+          run_id: metadata.run_id,
+          oracle_result: {
+            outcome_checks_passed: oracleCheck.outcome_checks_passed,
+            required_events_met: requiredEventsMet,
+            failure_tags: oracleCheck.failure_tags,
+            ambiguity_reasons: oracleCheck.ambiguity_reasons,
+            trace_warnings: traceLog.warnings,
+          },
+          run_metrics: deriveRunMetrics(traceLog.warnings, requiredEventsMet.length),
+          evidence_paths: {
+            transcript: 'transcript.jsonl',
+            event_log: 'event-log.json',
+            artifacts: 'artifacts',
+          },
+        });
+        const writtenVerdict = writeVerdictArtifact(join(runDir, 'verdict.json'), verdict);
+        if (writtenVerdict.human_review_required) {
+          createReviewTicket({
+            run_dir: runDir,
+            review_reason: writtenVerdict.review_reason,
+            failure_tags: writtenVerdict.failure_tags,
+          });
+        }
+
+        runs.push({
+          run_id: metadata.run_id,
+          case_id: metadata.case_id,
+          status: writtenVerdict.status,
+          auto_verdict: writtenVerdict.auto_verdict,
+          total_score: writtenVerdict.total_score,
+          review_reason: writtenVerdict.review_reason,
+          warnings: traceLog.warnings,
+        });
+      }
+
+      return {
+        command_group: 'benchmark',
+        subcommand: 'evaluate',
+        runs,
+      };
+    });
+  });
+
+benchmark
+  .command('report <runsRoot>')
+  .description('Build machine-readable JSON and Markdown benchmark reports')
+  .option('--baseline <path>', 'optional baseline runs root')
+  .option('--json-out <path>', 'path for the JSON report')
+  .option('--markdown-out <path>', 'path for the Markdown report')
+  .action(async (runsRoot: string, options: { baseline?: string; jsonOut?: string; markdownOut?: string }) => {
+    await runBenchmarkCommand(() => {
+      const resolvedRunsRoot = resolve(runsRoot);
+      const jsonReportPath = resolve(options.jsonOut ?? join(resolvedRunsRoot, 'report.json'));
+      const markdownReportPath = resolve(options.markdownOut ?? join(resolvedRunsRoot, 'report.md'));
+      const report = buildJsonReport({
+        runs_root: resolvedRunsRoot,
+        baseline_root: options.baseline ? resolve(options.baseline) : undefined,
+      });
+      const markdown = buildMarkdownReport(report);
+
+      writeFileSync(jsonReportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf-8');
+      writeFileSync(markdownReportPath, `${markdown}\n`, 'utf-8');
+
+      return {
+        command_group: 'benchmark',
+        subcommand: 'report',
+        json_report_path: jsonReportPath,
+        markdown_report_path: markdownReportPath,
+        run_count: report.summary.run_count,
+        baseline_run_count: report.summary.baseline_run_count,
+      };
+    });
+  });
+
+benchmark
+  .command('review-apply <runDir>')
+  .description('Persist a final human review verdict without removing the automatic evidence')
+  .requiredOption('--verdict <value>', 'final verdict to apply: pass or fail')
+  .option('--reviewer <name>', 'reviewer identity')
+  .option('--notes <text>', 'optional human review notes')
+  .action(async (runDir: string, options: { verdict: 'pass' | 'fail'; reviewer?: string; notes?: string }) => {
+    await runBenchmarkCommand(() => {
+      if (options.verdict !== 'pass' && options.verdict !== 'fail') {
+        throw new Error('review verdict must be pass or fail');
+      }
+
+      const resolvedRunDir = resolve(runDir);
+      const result = applyHumanReview({
+        run_dir: resolvedRunDir,
+        final_verdict: options.verdict,
+        reviewer: options.reviewer,
+        notes: options.notes,
+      });
+
+      return {
+        command_group: 'benchmark',
+        subcommand: 'review-apply',
+        run_dir: resolvedRunDir,
+        final_verdict: result.verdict.final_verdict,
+        reviewed_by: result.review_record.reviewed_by,
+        reviewed_at: result.review_record.reviewed_at,
+      };
+    });
+  });
+
+await program.parseAsync(process.argv);
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -230,4 +492,184 @@ function getVersion(): string {
   } catch {
     return '0.0.0';
   }
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as T;
+}
+
+function formatRunId(caseId: string, index: number): string {
+  return `${caseId}-${Date.now()}-${String(index + 1).padStart(2, '0')}`;
+}
+
+function isBenchmarkValidationError(error: unknown): error is BenchmarkValidationError {
+  return typeof error === 'object'
+    && error !== null
+    && 'code' in error
+    && 'details' in error;
+}
+
+function reportCommandError(error: unknown): void {
+  const payload = isBenchmarkValidationError(error)
+    ? {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      }
+    : {
+        code: 'command_failed',
+        message: error instanceof Error ? error.message : String(error),
+        details: {},
+      };
+
+  err(JSON.stringify(payload, null, 2));
+  process.exitCode = 1;
+}
+
+async function runBenchmarkCommand<T>(operation: () => T | Promise<T>): Promise<void> {
+  try {
+    const payload = await operation();
+    out(JSON.stringify(payload, null, 2));
+  } catch (error) {
+    reportCommandError(error);
+  }
+}
+
+function resolveRunDirectories(runPath: string): string[] {
+  const resolvedPath = resolve(runPath);
+  const metadataPath = join(resolvedPath, 'metadata.json');
+  if (existsSync(metadataPath) && statSync(metadataPath).isFile()) {
+    return [resolvedPath];
+  }
+
+  if (!existsSync(resolvedPath) || !statSync(resolvedPath).isDirectory()) {
+    throw new Error(`benchmark run path not found: ${resolvedPath}`);
+  }
+
+  return readdirSync(resolvedPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(resolvedPath, entry.name))
+    .filter((entry) => existsSync(join(entry, 'metadata.json')));
+}
+
+function readTranscriptRecords(runDir: string): BenchmarkTranscriptRecord[] {
+  const transcriptJsonPath = join(runDir, 'transcript.json');
+  if (existsSync(transcriptJsonPath) && statSync(transcriptJsonPath).isFile()) {
+    return readJsonFile<BenchmarkTranscriptRecord[]>(transcriptJsonPath);
+  }
+
+  const transcriptPath = join(runDir, 'transcript.jsonl');
+  return readFileSync(transcriptPath, 'utf-8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as BenchmarkTranscriptRecord);
+}
+
+function collectArtifactChanges(artifactsRoot: string): BenchmarkArtifactChange[] {
+  if (!existsSync(artifactsRoot) || !statSync(artifactsRoot).isDirectory()) {
+    return [];
+  }
+
+  const changes: BenchmarkArtifactChange[] = [];
+  const timestamp = new Date().toISOString();
+
+  const visit = (dirPath: string): void => {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      const entryPath = join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        visit(entryPath);
+        continue;
+      }
+
+      changes.push({
+        timestamp,
+        path: relative(artifactsRoot, entryPath).replace(/\\/g, '/'),
+        change_type: 'added',
+      });
+    }
+  };
+
+  visit(artifactsRoot);
+  return changes;
+}
+
+function mapRequiredEvents(semanticEvents: ReturnType<typeof deriveSemanticEvents>['semantic_events']): string[] {
+  return semanticEvents.map((event) => {
+    if (event.type === 'phase_entered') {
+      return `phase_entered:${event.details.phase ?? 'unknown'}`;
+    }
+
+    if (event.type === 'independent_review_dispatched') {
+      return `independent_review_dispatched:${event.details.reviewer ?? 'unknown'}`;
+    }
+
+    return `fresh_reverification:${event.details.tool ?? 'unknown'}`;
+  });
+}
+
+function evaluateOracleChecks(
+  oracle: BenchmarkOracle,
+  runDir: string,
+  requiredEventsMet: string[],
+): {
+  outcome_checks_passed: boolean;
+  failure_tags: string[];
+  ambiguity_reasons: string[];
+} {
+  const failureTags: string[] = [];
+  const ambiguityReasons: string[] = [];
+  let outcomeChecksPassed = oracle.verdict !== 'fail';
+
+  for (const check of oracle.checks ?? []) {
+    const normalizedCheck = check.trim().toLowerCase();
+    if (normalizedCheck.length === 0) {
+      continue;
+    }
+
+    if (normalizedCheck === 'build') {
+      const hasBuildArtifact = existsSync(join(runDir, 'artifacts', 'logs', 'result.json'));
+      if (!hasBuildArtifact) {
+        outcomeChecksPassed = false;
+        failureTags.push('F11');
+      }
+      continue;
+    }
+
+    if (normalizedCheck === 'tests') {
+      const hasFreshReverify = requiredEventsMet.some((event) => event.startsWith('fresh_reverification:'));
+      if (!hasFreshReverify) {
+        ambiguityReasons.push('oracle_tests_check_unverifiable');
+      }
+      continue;
+    }
+
+    ambiguityReasons.push(`unknown_oracle_check:${normalizedCheck}`);
+  }
+
+  return {
+    outcome_checks_passed: outcomeChecksPassed,
+    failure_tags: failureTags,
+    ambiguity_reasons: ambiguityReasons,
+  };
+}
+
+function deriveRunMetrics(warnings: string[], semanticEventCount: number): {
+  process_score: number;
+  outcome_score: number;
+  efficiency_score: number;
+} {
+  if (warnings.length > 0) {
+    return {
+      process_score: 32,
+      outcome_score: 0,
+      efficiency_score: 5,
+    };
+  }
+
+  return {
+    process_score: semanticEventCount > 0 ? 40 : 25,
+    outcome_score: 30,
+    efficiency_score: 10,
+  };
 }

--- a/src/nopilot-cli.ts
+++ b/src/nopilot-cli.ts
@@ -320,6 +320,7 @@ benchmark
           repo_fixture_hash: bundle.fixture_hash,
           trace_extractor_version: DEFAULT_TRACE_EXTRACTOR_VERSION,
           run_profile: profile.profile_id,
+          adapter_exit_code: adapterResult.exit_code,
         };
         const runOutput = writeStandardRunDirectory(metadata, adapterResult, outputRoot);
 
@@ -381,6 +382,39 @@ benchmark
             });
             continue;
           }
+        }
+
+        if ((metadata.adapter_exit_code ?? 0) !== 0) {
+          const verdict = composeVerdict({
+            run_id: metadata.run_id,
+            oracle_result: {
+              outcome_checks_passed: false,
+              failure_tags: ['F11'],
+              ambiguity_reasons: [],
+              trace_warnings: [],
+            },
+            run_metrics: {
+              process_score: 25,
+              outcome_score: 0,
+              efficiency_score: 0,
+            },
+            evidence_paths: {
+              transcript: 'transcript.jsonl',
+              event_log: 'event-log.json',
+              artifacts: 'artifacts',
+            },
+          });
+          const writtenVerdict = writeVerdictArtifact(join(runDir, 'verdict.json'), verdict);
+          runs.push({
+            run_id: metadata.run_id,
+            case_id: metadata.case_id,
+            status: writtenVerdict.status,
+            auto_verdict: writtenVerdict.auto_verdict,
+            total_score: writtenVerdict.total_score,
+            review_reason: writtenVerdict.review_reason,
+            warnings: [],
+          });
+          continue;
         }
 
         const transcript = readTranscriptRecords(runDir);

--- a/tests/benchmark-contracts.test.ts
+++ b/tests/benchmark-contracts.test.ts
@@ -1,0 +1,346 @@
+import { createHash } from 'node:crypto';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadBenchmarkCase } from '../src/benchmark/case-loader.js';
+import {
+  getPhase1RunProfile,
+  validateRunContract,
+} from '../src/benchmark/run-profile.js';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, JSON.stringify(value, null, 2), 'utf-8');
+}
+
+function computeExpectedFixtureHash(files: Record<string, string>): string {
+  const hash = createHash('sha256');
+  const names = Object.keys(files).sort();
+
+  for (const name of names) {
+    hash.update(name);
+    hash.update('\n');
+    hash.update(files[name]);
+    hash.update('\n');
+  }
+
+  return hash.digest('hex');
+}
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('loadBenchmarkCase', () => {
+  it('rejects a case missing required files and required metadata fields with structured details', () => {
+    const caseDir = makeTempDir('benchmark-case-');
+    cleanupPaths.push(caseDir);
+
+    mkdirSync(join(caseDir, 'fixture'), { recursive: true });
+    writeJson(join(caseDir, 'case.json'), {
+      id: 'CASE-001',
+      case_version: '2026-04-09',
+      fixture: 'fixture',
+    });
+    writeFileSync(join(caseDir, 'prompt.txt'), 'Do the task.\n', 'utf-8');
+
+    try {
+      loadBenchmarkCase(caseDir);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'case_missing_file',
+        details: {
+          missingFiles: ['oracle.json'],
+        },
+      });
+    }
+  });
+
+  it('reports invalid case.json as case_schema_invalid instead of throwing SyntaxError', () => {
+    const caseDir = makeTempDir('benchmark-case-');
+    cleanupPaths.push(caseDir);
+
+    mkdirSync(join(caseDir, 'fixture'), { recursive: true });
+    writeFileSync(join(caseDir, 'case.json'), '{"id": "CASE-003",', 'utf-8');
+    writeFileSync(join(caseDir, 'prompt.txt'), 'Broken case JSON.\n', 'utf-8');
+    writeJson(join(caseDir, 'oracle.json'), {
+      verdict: 'pass',
+    });
+
+    try {
+      loadBenchmarkCase(caseDir);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'case_schema_invalid',
+      });
+    }
+  });
+
+  it('reports invalid oracle.json as oracle_schema_invalid instead of throwing SyntaxError', () => {
+    const caseDir = makeTempDir('benchmark-case-');
+    cleanupPaths.push(caseDir);
+
+    mkdirSync(join(caseDir, 'fixture'), { recursive: true });
+    writeJson(join(caseDir, 'case.json'), {
+      id: 'CASE-004',
+      case_version: '2026-04-09',
+      run_profile: 'phase1-local-cli-v1',
+      fixture: 'fixture',
+      budget: {
+        max_turns: 5,
+        timeout_seconds: 120,
+        max_cost_usd: 2,
+      },
+    });
+    writeFileSync(join(caseDir, 'prompt.txt'), 'Broken oracle JSON.\n', 'utf-8');
+    writeFileSync(join(caseDir, 'oracle.json'), '{"verdict":', 'utf-8');
+
+    try {
+      loadBenchmarkCase(caseDir);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'oracle_schema_invalid',
+      });
+    }
+  });
+
+  it('loads a valid case and preserves case version and fixture hash in run metadata seed fields', () => {
+    const caseDir = makeTempDir('benchmark-case-');
+    cleanupPaths.push(caseDir);
+
+    const fixtureFiles = {
+      'README.md': '# fixture\n',
+      'src/index.ts': 'export const value = 1;\n',
+    };
+
+    mkdirSync(join(caseDir, 'fixture', 'src'), { recursive: true });
+    writeJson(join(caseDir, 'case.json'), {
+      id: 'CASE-002',
+      case_version: '2026-04-09',
+      run_profile: 'phase1-local-cli-v1',
+      fixture: 'fixture',
+      budget: {
+        max_turns: 5,
+        timeout_seconds: 120,
+        max_cost_usd: 2,
+      },
+    });
+    writeFileSync(join(caseDir, 'prompt.txt'), 'Implement the behavior.\n', 'utf-8');
+    writeJson(join(caseDir, 'oracle.json'), {
+      verdict: 'pass',
+      checks: ['build', 'tests'],
+    });
+    writeFileSync(join(caseDir, 'fixture', 'README.md'), fixtureFiles['README.md'], 'utf-8');
+    writeFileSync(join(caseDir, 'fixture', 'src', 'index.ts'), fixtureFiles['src/index.ts'], 'utf-8');
+
+    const bundle = loadBenchmarkCase(caseDir);
+
+    expect(bundle.case.id).toBe('CASE-002');
+    expect(bundle.case.case_version).toBe('2026-04-09');
+    expect(bundle.case.run_profile).toBe('phase1-local-cli-v1');
+    expect(bundle.fixture_dir).toBe(join(caseDir, 'fixture'));
+    expect(bundle.fixture_hash).toBe(computeExpectedFixtureHash(fixtureFiles));
+    expect(bundle.run_metadata_seed).toEqual({
+      case_id: 'CASE-002',
+      case_version: '2026-04-09',
+      repo_fixture_hash: computeExpectedFixtureHash(fixtureFiles),
+    });
+  });
+});
+
+describe('getPhase1RunProfile', () => {
+  it('returns the frozen phase1-local-cli-v1 profile and rejects unsupported profiles', () => {
+    const profile = getPhase1RunProfile('phase1-local-cli-v1');
+
+    expect(profile.profile_id).toBe('phase1-local-cli-v1');
+    expect(profile.required_artifacts).toEqual([
+      'metadata.json',
+      'transcript.jsonl',
+      'artifacts',
+      'event-log.json',
+      'verdict.json',
+    ]);
+    expect(profile.required_metadata_fields).toEqual([
+      'run_id',
+      'case_id',
+      'case_version',
+      'platform_id',
+      'model_id',
+      'workflow_version',
+      'repo_fixture_hash',
+      'trace_extractor_version',
+    ]);
+    expect(profile.transcript_record_fields).toEqual([
+      'timestamp',
+      'role',
+      'event_type',
+      'content',
+    ]);
+
+    expect(() => getPhase1RunProfile('phase1-other-profile')).toThrow('unsupported_profile');
+  });
+});
+
+describe('validateRunContract', () => {
+  it('rejects a run directory whose metadata omits required phase1 fields', () => {
+    const runDir = makeTempDir('benchmark-run-');
+    cleanupPaths.push(runDir);
+
+    mkdirSync(join(runDir, 'artifacts'), { recursive: true });
+    writeJson(join(runDir, 'metadata.json'), {
+      run_id: 'RUN-001',
+      case_id: 'CASE-001',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-1',
+      repo_fixture_hash: 'abc123',
+    });
+    writeFileSync(
+      join(runDir, 'transcript.jsonl'),
+      `${JSON.stringify({
+        timestamp: '2026-04-09T10:00:00.000Z',
+        role: 'assistant',
+        event_type: 'message',
+        content: 'started',
+      })}\n`,
+      'utf-8',
+    );
+    writeJson(join(runDir, 'event-log.json'), []);
+    writeJson(join(runDir, 'verdict.json'), {
+      status: 'pending_review',
+    });
+
+    const result = validateRunContract(runDir, 'phase1-local-cli-v1');
+
+    expect(result.valid).toBe(false);
+    expect(result.missing_fields).toEqual([
+      'case_version',
+      'trace_extractor_version',
+    ]);
+    expect(result.errors).toContain('missing required metadata fields');
+  });
+
+  it('reports invalid metadata.json as run_schema_invalid instead of throwing SyntaxError', () => {
+    const runDir = makeTempDir('benchmark-run-');
+    cleanupPaths.push(runDir);
+
+    mkdirSync(join(runDir, 'artifacts'), { recursive: true });
+    writeFileSync(join(runDir, 'metadata.json'), '{"run_id":', 'utf-8');
+    writeFileSync(
+      join(runDir, 'transcript.jsonl'),
+      `${JSON.stringify({
+        timestamp: '2026-04-09T10:00:00.000Z',
+        role: 'assistant',
+        event_type: 'message',
+        content: 'started',
+      })}\n`,
+      'utf-8',
+    );
+    writeJson(join(runDir, 'event-log.json'), []);
+    writeJson(join(runDir, 'verdict.json'), {
+      status: 'pending_review',
+    });
+
+    const result = validateRunContract(runDir, 'phase1-local-cli-v1');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('run_schema_invalid');
+  });
+
+  it('requires run_profile and flags profile_mismatch when metadata profile differs', () => {
+    const runDir = makeTempDir('benchmark-run-');
+    cleanupPaths.push(runDir);
+
+    mkdirSync(join(runDir, 'artifacts'), { recursive: true });
+    writeJson(join(runDir, 'metadata.json'), {
+      run_id: 'RUN-003',
+      case_id: 'CASE-003',
+      case_version: '2026-04-09',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-1',
+      repo_fixture_hash: 'fixture-hash-123',
+      trace_extractor_version: 'trace-v1',
+      run_profile: 'phase1-other-profile',
+    });
+    writeFileSync(
+      join(runDir, 'transcript.jsonl'),
+      `${JSON.stringify({
+        timestamp: '2026-04-09T10:00:00.000Z',
+        role: 'assistant',
+        event_type: 'message',
+        content: 'started',
+      })}\n`,
+      'utf-8',
+    );
+    writeJson(join(runDir, 'event-log.json'), []);
+    writeJson(join(runDir, 'verdict.json'), {
+      status: 'pending_review',
+    });
+
+    const result = validateRunContract(runDir, 'phase1-local-cli-v1');
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('profile_mismatch');
+  });
+
+  it('accepts a complete standard run directory', () => {
+    const runDir = makeTempDir('benchmark-run-');
+    cleanupPaths.push(runDir);
+
+    mkdirSync(join(runDir, 'artifacts'), { recursive: true });
+    writeJson(join(runDir, 'metadata.json'), {
+      run_id: 'RUN-002',
+      case_id: 'CASE-002',
+      case_version: '2026-04-09',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-1',
+      repo_fixture_hash: 'fixture-hash-123',
+      trace_extractor_version: 'trace-v1',
+      run_profile: 'phase1-local-cli-v1',
+    });
+    writeFileSync(
+      join(runDir, 'transcript.jsonl'),
+      `${JSON.stringify({
+        timestamp: '2026-04-09T10:00:00.000Z',
+        role: 'assistant',
+        event_type: 'message',
+        content: 'started',
+      })}\n`,
+      'utf-8',
+    );
+    writeJson(join(runDir, 'event-log.json'), []);
+    writeJson(join(runDir, 'verdict.json'), {
+      status: 'pending_review',
+    });
+
+    const result = validateRunContract(runDir, 'phase1-local-cli-v1');
+
+    expect(result.valid).toBe(true);
+    expect(result.missing_fields).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.metadata).toMatchObject({
+      case_id: 'CASE-002',
+      case_version: '2026-04-09',
+      repo_fixture_hash: 'fixture-hash-123',
+      trace_extractor_version: 'trace-v1',
+    });
+  });
+});

--- a/tests/benchmark-evaluation.test.ts
+++ b/tests/benchmark-evaluation.test.ts
@@ -1,0 +1,357 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkOracle } from '../src/benchmark/oracle-checker.js';
+import {
+  collectUnknownFailureTags,
+  FAILURE_TAG_DEFINITIONS,
+  FAILURE_TAG_PRECEDENCE,
+  getFailureTagNames,
+  selectPrimaryFailureTag,
+} from '../src/benchmark/failure-taxonomy.js';
+import { scoreRun } from '../src/benchmark/scorer.js';
+import { composeVerdict, writeVerdictArtifact } from '../src/benchmark/verdict-writer.js';
+import { validateBenchmarkSchema } from '../src/benchmark/schema-loader.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+describe('benchmark evaluation taxonomy', () => {
+  it('defines the fixed phase-1 failure taxonomy and precedence order', () => {
+    expect(FAILURE_TAG_PRECEDENCE).toEqual([
+      'F1',
+      'F2',
+      'F3',
+      'F4',
+      'F5',
+      'F6',
+      'F7',
+      'F8',
+      'F9',
+      'F10',
+      'F11',
+    ]);
+
+    expect(
+      Object.fromEntries(
+        Object.entries(FAILURE_TAG_DEFINITIONS).map(([code, definition]) => [code, definition.key]),
+      ),
+    ).toEqual({
+      F1: 'wrong_skill_or_command_route',
+      F2: 'skipped_required_stage',
+      F3: 'generation_review_not_separated',
+      F4: 'missing_fresh_reverify',
+      F5: 'stage_leakage',
+      F6: 'missing_prerequisite_input_check',
+      F7: 'explicit_user_intent_not_honored',
+      F8: 'parallel_isolation_missing',
+      F9: 'subagent_completion_not_verified',
+      F10: 'trace_insufficient',
+      F11: 'artifact_contract_mismatch',
+    });
+
+    expect(selectPrimaryFailureTag(['F7', 'F2', 'F10'])).toBe('F2');
+    expect(collectUnknownFailureTags(['F1', 'FX', 'F10', 'BAD'])).toEqual(['BAD', 'FX']);
+    expect(getFailureTagNames(['F10', 'F1'])).toEqual([
+      'wrong_skill_or_command_route',
+      'trace_insufficient',
+    ]);
+  });
+});
+
+describe('checkOracle', () => {
+  it('classifies trace insufficiency as F10 and records semantic ambiguity for review', () => {
+    const result = checkOracle({
+      required_events_met: ['phase_entered:discover'],
+      trace_warnings: [
+        'trace_insufficient: cannot_determine_fresh_reverify',
+      ],
+    });
+
+    expect(result).toMatchObject({
+      required_events_met: ['phase_entered:discover'],
+      failure_tags: ['F10'],
+      review_reason: ['semantic_ambiguity'],
+      trace_insufficient_reasons: ['cannot_determine_fresh_reverify'],
+    });
+  });
+});
+
+describe('scoreRun', () => {
+  it('caps F1-F4 process failures and excludes efficiency from the total', () => {
+    const result = scoreRun({
+      process_score: 45,
+      outcome_score: 10,
+      efficiency_score: 20,
+      failure_tags: ['F4'],
+    });
+
+    expect(result).toMatchObject({
+      process_score: 20,
+      outcome_score: 10,
+      efficiency_score: 20,
+      counted_efficiency_score: 0,
+      total_score: 30,
+      efficiency_excluded: true,
+      process_fail: true,
+    });
+  });
+
+  it.each([
+    { process_score: 0, outcome_score: 30, efficiency_score: 20 },
+    { process_score: 18, outcome_score: 26, efficiency_score: 20 },
+    { process_score: 24, outcome_score: 1, efficiency_score: 20 },
+  ])(
+    'marks any run below the process threshold as process_fail: %j',
+    ({ process_score, outcome_score, efficiency_score }) => {
+      const result = scoreRun({
+        process_score,
+        outcome_score,
+        efficiency_score,
+      });
+
+      expect(result.process_fail).toBe(true);
+      expect(result.total_score).toBe(process_score + outcome_score);
+      expect(result.counted_efficiency_score).toBe(0);
+    },
+  );
+
+  it('rejects scores outside the phase-1 scoring envelope', () => {
+    expect(() => scoreRun({
+      process_score: 51,
+      outcome_score: 30,
+      efficiency_score: 20,
+    })).toThrow('score_gate_violation');
+
+    expect(() => scoreRun({
+      process_score: 50,
+      outcome_score: 31,
+      efficiency_score: 20,
+    })).toThrow('score_gate_violation');
+
+    expect(() => scoreRun({
+      process_score: 50,
+      outcome_score: 30,
+      efficiency_score: 21,
+    })).toThrow('score_gate_violation');
+  });
+});
+
+describe('composeVerdict', () => {
+  it('emits process_fail and excludes efficiency when process score drops below 25', () => {
+    const verdict = composeVerdict({
+      run_id: 'RUN-007',
+      oracle_result: {
+        core_process_violations: ['F1', 'F3'],
+        outcome_checks_passed: true,
+      },
+      run_metrics: {
+        process_score: 18,
+        outcome_score: 26,
+        efficiency_score: 20,
+      },
+    });
+
+    expect(verdict).toMatchObject({
+      status: 'fail',
+      auto_verdict: 'process_fail',
+      total_score: 44,
+      primary_failure_tag: 'F1',
+      failure_tags: ['F1', 'F3'],
+      score_breakdown: {
+        process_score: 18,
+        outcome_score: 26,
+        efficiency_score: 20,
+        counted_efficiency_score: 0,
+        efficiency_excluded: true,
+      },
+    });
+  });
+
+  it('assigns fallback taxonomy tags when process_fail has no explicit failure tags', () => {
+    const verdict = composeVerdict({
+      run_id: 'RUN-007B',
+      oracle_result: {
+        outcome_checks_passed: true,
+      },
+      run_metrics: {
+        process_score: 10,
+        outcome_score: 3,
+        efficiency_score: 20,
+      },
+    });
+
+    expect(verdict.auto_verdict).toBe('process_fail');
+    expect(verdict.failure_tags).toEqual(['F11']);
+    expect(verdict.primary_failure_tag).toBe('F11');
+  });
+
+  it('emits needs_review with F10 and preserves evidence for human review', () => {
+    const outputDir = makeTempDir('benchmark-verdict-');
+    const verdictPath = join(outputDir, 'verdict.json');
+    const verdict = composeVerdict({
+      run_id: 'RUN-008',
+      oracle_result: {
+        required_events_met: ['phase_entered:discover'],
+        trace_warnings: [
+          'trace_insufficient: cannot_determine_fresh_reverify',
+        ],
+      },
+      run_metrics: {
+        process_score: 32,
+        outcome_score: 0,
+        efficiency_score: 5,
+      },
+      evidence_paths: {
+        transcript: 'transcript.jsonl',
+        event_log: 'event-log.json',
+        artifacts: 'artifacts',
+      },
+    });
+
+    const written = writeVerdictArtifact(verdictPath, verdict);
+    const onDisk = JSON.parse(readFileSync(verdictPath, 'utf-8')) as unknown;
+    const validation = validateBenchmarkSchema('benchmark-verdict', onDisk);
+
+    expect(validation).toMatchObject({ valid: true, errors: [] });
+    expect(written).toMatchObject({
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      failure_tags: ['F10'],
+      failure_tag_names: ['trace_insufficient'],
+      primary_failure_tag: 'F10',
+      human_review_required: true,
+      final_verdict: null,
+      review_reason: ['semantic_ambiguity'],
+      review_ticket: {
+        status: 'pending_review',
+        run_dir: 'RUN-008',
+        review_reason: ['semantic_ambiguity'],
+        failure_tags: ['F10'],
+        preserved_evidence: {
+          transcript: 'transcript.jsonl',
+          event_log: 'event-log.json',
+          artifacts: 'artifacts',
+        },
+      },
+      trace_insufficient_reasons: ['cannot_determine_fresh_reverify'],
+    });
+    expect(onDisk).toEqual(written);
+  });
+
+  it('requires complete review evidence when emitting needs_review', () => {
+    expect(() => composeVerdict({
+      run_id: 'RUN-008B',
+      oracle_result: {
+        ambiguity_reasons: ['manual_judgement_required'],
+      },
+      run_metrics: {
+        process_score: 35,
+        outcome_score: 5,
+        efficiency_score: 5,
+      },
+      evidence_paths: {
+        transcript: 'transcript.jsonl',
+        event_log: 'event-log.json',
+        artifacts: '',
+      },
+    })).toThrow('benchmark_review_evidence_missing');
+  });
+
+  it('forces F10 when a verdict becomes needs_review due to ambiguity reasons', () => {
+    const verdict = composeVerdict({
+      run_id: 'RUN-008C',
+      oracle_result: {
+        ambiguity_reasons: ['manual_judgement_required'],
+      },
+      run_metrics: {
+        process_score: 35,
+        outcome_score: 5,
+        efficiency_score: 5,
+      },
+      evidence_paths: {
+        transcript: 'transcript.jsonl',
+        event_log: 'event-log.json',
+        artifacts: 'artifacts',
+      },
+    });
+
+    expect(verdict.auto_verdict).toBe('needs_review');
+    expect(verdict.failure_tags).toContain('F10');
+    expect(verdict.primary_failure_tag).toBe('F10');
+  });
+
+  it('returns pass when outcome passes and no failures or ambiguity are present', () => {
+    const verdict = composeVerdict({
+      run_id: 'RUN-009',
+      oracle_result: {
+        outcome_checks_passed: true,
+      },
+      run_metrics: {
+        process_score: 30,
+        outcome_score: 30,
+        efficiency_score: 20,
+      },
+    });
+
+    expect(verdict).toMatchObject({
+      status: 'pass',
+      auto_verdict: 'pass',
+      failure_tags: [],
+      failure_tag_names: [],
+      primary_failure_tag: null,
+      human_review_required: false,
+      final_verdict: null,
+      review_reason: [],
+      total_score: 80,
+      score_breakdown: {
+        process_score: 30,
+        outcome_score: 30,
+        efficiency_score: 20,
+        counted_efficiency_score: 20,
+        efficiency_excluded: false,
+      },
+    });
+  });
+
+  it('rejects unknown failure tags instead of silently dropping them', () => {
+    expect(() => composeVerdict({
+      run_id: 'RUN-010',
+      oracle_result: {
+        failure_tags: ['FX'],
+        outcome_checks_passed: false,
+      },
+      run_metrics: {
+        process_score: 30,
+        outcome_score: 0,
+        efficiency_score: 0,
+      },
+    })).toThrow('unknown_failure_tag');
+  });
+
+  it('rejects impossible score inputs instead of emitting an out-of-range verdict', () => {
+    expect(() => composeVerdict({
+      run_id: 'RUN-011',
+      oracle_result: {
+        outcome_checks_passed: true,
+      },
+      run_metrics: {
+        process_score: 999,
+        outcome_score: 30,
+        efficiency_score: 20,
+      },
+    })).toThrow('score_gate_violation');
+  });
+});

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -451,6 +451,68 @@ describe('benchmark reporter', () => {
     ]);
   });
 
+  it('falls back to stable same-key pairing when no workflow version matches exist', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-B', {
+      case_id: 'DISCOVER-008',
+      workflow_version: 'wf-b',
+      total_score: 70,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(currentRoot, 'RUN-C', {
+      case_id: 'DISCOVER-008',
+      workflow_version: 'wf-c',
+      total_score: 50,
+      status: 'fail',
+      auto_verdict: 'fail',
+      failure_tags: ['F2'],
+      primary_failure_tag: 'F2',
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-A', {
+      case_id: 'DISCOVER-008',
+      workflow_version: 'wf-a',
+      total_score: 60,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(baselineRoot, 'BASE-D', {
+      case_id: 'DISCOVER-008',
+      workflow_version: 'wf-d',
+      total_score: 55,
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      human_review_required: true,
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.summary).toMatchObject({
+      matched_cases: 2,
+      added_cases: 0,
+      removed_cases: 0,
+    });
+    expect(report.regression_diff.entries).toEqual([
+      expect.objectContaining({
+        baseline_run_id: 'BASE-A',
+        current_run_id: 'RUN-B',
+      }),
+      expect.objectContaining({
+        baseline_run_id: 'BASE-D',
+        current_run_id: 'RUN-C',
+      }),
+    ]);
+  });
+
   it('keeps regression diff empty when no baseline root is provided', () => {
     const currentRoot = makeTempDir('benchmark-current-');
     cleanupPaths.push(currentRoot);

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -513,6 +513,55 @@ describe('benchmark reporter', () => {
     ]);
   });
 
+  it('prefers later exact workflow matches before using fallback pairing for the remaining runs', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-A', {
+      case_id: 'DISCOVER-009',
+      workflow_version: 'wf-a',
+      total_score: 40,
+      status: 'fail',
+      auto_verdict: 'fail',
+      failure_tags: ['F2'],
+      primary_failure_tag: 'F2',
+    });
+    writeRunFixture(currentRoot, 'RUN-B', {
+      case_id: 'DISCOVER-009',
+      workflow_version: 'wf-b',
+      total_score: 88,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-B', {
+      case_id: 'DISCOVER-009',
+      workflow_version: 'wf-b',
+      total_score: 82,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.entries).toEqual([
+      expect.objectContaining({
+        baseline_run_id: 'BASE-B',
+        current_run_id: 'RUN-B',
+        classification: 'improved',
+      }),
+      expect.objectContaining({
+        baseline_run_id: null,
+        current_run_id: 'RUN-A',
+        classification: 'added',
+      }),
+    ]);
+  });
+
   it('keeps regression diff empty when no baseline root is provided', () => {
     const currentRoot = makeTempDir('benchmark-current-');
     cleanupPaths.push(currentRoot);

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -358,6 +358,50 @@ describe('benchmark reporter', () => {
     ]);
   });
 
+  it('preserves multiple runs that share the same case/platform/model key instead of overwriting them', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-401', {
+      case_id: 'DISCOVER-006',
+      total_score: 70,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(currentRoot, 'RUN-402', {
+      case_id: 'DISCOVER-006',
+      total_score: 65,
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      human_review_required: true,
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-401', {
+      case_id: 'DISCOVER-006',
+      total_score: 72,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(baselineRoot, 'BASE-402', {
+      case_id: 'DISCOVER-006',
+      total_score: 67,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.entries).toHaveLength(2);
+    expect(report.regression_diff.entries.map((entry) => entry.current_run_id)).toEqual(['RUN-401', 'RUN-402']);
+    expect(report.regression_diff.entries.map((entry) => entry.baseline_run_id)).toEqual(['BASE-401', 'BASE-402']);
+  });
+
   it('keeps regression diff empty when no baseline root is provided', () => {
     const currentRoot = makeTempDir('benchmark-current-');
     cleanupPaths.push(currentRoot);

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -402,6 +402,55 @@ describe('benchmark reporter', () => {
     expect(report.regression_diff.entries.map((entry) => entry.baseline_run_id)).toEqual(['BASE-401', 'BASE-402']);
   });
 
+  it('matches same-key runs by workflow version before falling back to run id order', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-Z', {
+      case_id: 'DISCOVER-007',
+      workflow_version: 'wf-z',
+      total_score: 91,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-A', {
+      case_id: 'DISCOVER-007',
+      workflow_version: 'wf-a',
+      total_score: 40,
+      status: 'fail',
+      auto_verdict: 'fail',
+      failure_tags: ['F2'],
+      primary_failure_tag: 'F2',
+    });
+    writeRunFixture(baselineRoot, 'BASE-Z', {
+      case_id: 'DISCOVER-007',
+      workflow_version: 'wf-z',
+      total_score: 89,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.entries).toEqual([
+      expect.objectContaining({
+        baseline_run_id: 'BASE-Z',
+        current_run_id: 'RUN-Z',
+        classification: 'improved',
+      }),
+      expect.objectContaining({
+        baseline_run_id: 'BASE-A',
+        current_run_id: null,
+        classification: 'removed',
+      }),
+    ]);
+  });
+
   it('keeps regression diff empty when no baseline root is provided', () => {
     const currentRoot = makeTempDir('benchmark-current-');
     cleanupPaths.push(currentRoot);

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -1,0 +1,352 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildJsonReport,
+  buildMarkdownReport,
+} from '../src/benchmark/reporter.js';
+import { validateBenchmarkSchema } from '../src/benchmark/schema-loader.js';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function writeRunFixture(
+  rootDir: string,
+  runId: string,
+  overrides: Partial<{
+    case_id: string;
+    case_version: string;
+    platform_id: string;
+    model_id: string;
+    workflow_version: string;
+    repo_fixture_hash: string;
+    trace_extractor_version: string;
+    run_profile: string;
+    status: 'pass' | 'fail' | 'needs_review';
+    auto_verdict: 'pass' | 'fail' | 'process_fail' | 'needs_review';
+    total_score: number;
+    failure_tags: string[];
+    primary_failure_tag: string | null;
+    human_review_required: boolean;
+  }> = {},
+): void {
+  const runDir = join(rootDir, runId);
+  mkdirSync(runDir, { recursive: true });
+
+  writeJson(join(runDir, 'metadata.json'), {
+    run_id: runId,
+    case_id: overrides.case_id ?? runId,
+    case_version: overrides.case_version ?? '2026-04-09',
+      platform_id: overrides.platform_id ?? 'codex-cli',
+      model_id: overrides.model_id ?? 'gpt-5.4',
+    workflow_version: overrides.workflow_version ?? 'wf-1',
+    repo_fixture_hash: overrides.repo_fixture_hash ?? `fixture-${runId}`,
+    trace_extractor_version: overrides.trace_extractor_version ?? 'trace-v1',
+    run_profile: overrides.run_profile ?? 'phase1-local-cli-v1',
+  });
+
+  writeJson(join(runDir, 'verdict.json'), {
+    status: overrides.status ?? 'pass',
+    auto_verdict: overrides.auto_verdict ?? 'pass',
+    run_id: runId,
+    total_score: overrides.total_score ?? 80,
+    score_breakdown: {
+      process_score: 40,
+      outcome_score: 30,
+      efficiency_score: 10,
+      counted_efficiency_score: 10,
+      total_score: overrides.total_score ?? 80,
+      efficiency_excluded: false,
+      process_score_capped: false,
+      process_fail: false,
+    },
+    failure_tags: overrides.failure_tags ?? [],
+    failure_tag_names: [],
+    primary_failure_tag: overrides.primary_failure_tag ?? null,
+    human_review_required: overrides.human_review_required ?? false,
+    final_verdict: null,
+    review_reason: [],
+    required_events_met: [],
+    trace_insufficient_reasons: [],
+  });
+}
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('benchmark reporter', () => {
+  it('builds machine-readable and Markdown reports with leaderboard, failure breakdown, and regression diff sections', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-101', {
+      case_id: 'DISCOVER-001',
+      total_score: 91,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(currentRoot, 'RUN-102', {
+      case_id: 'DISCOVER-002',
+      total_score: 72,
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      human_review_required: true,
+    });
+    writeRunFixture(currentRoot, 'RUN-103', {
+      case_id: 'BUILD-001',
+      total_score: 44,
+      status: 'fail',
+      auto_verdict: 'process_fail',
+      failure_tags: ['F2', 'F10'],
+      primary_failure_tag: 'F2',
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-101', {
+      case_id: 'DISCOVER-001',
+      total_score: 80,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(baselineRoot, 'BASE-102', {
+      case_id: 'DISCOVER-002',
+      total_score: 78,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+    writeRunFixture(baselineRoot, 'BASE-103', {
+      case_id: 'BUILD-001',
+      total_score: 58,
+      status: 'fail',
+      auto_verdict: 'fail',
+      failure_tags: ['F2'],
+      primary_failure_tag: 'F2',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+    const markdown = buildMarkdownReport(report);
+    const validation = validateBenchmarkSchema('benchmark-report', report);
+
+    expect(validation).toMatchObject({ valid: true, errors: [] });
+    expect(report.generated_at).toEqual(expect.any(String));
+    expect(report.runs).toHaveLength(3);
+    expect(report.leaderboard).toEqual([
+      expect.objectContaining({
+        rank: 1,
+        run_id: 'RUN-101',
+        case_id: 'DISCOVER-001',
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workflow_version: 'wf-1',
+        total_score: 91,
+        status: 'pass',
+      }),
+      expect.objectContaining({
+        rank: 2,
+        run_id: 'RUN-102',
+        case_id: 'DISCOVER-002',
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workflow_version: 'wf-1',
+        total_score: 72,
+        status: 'needs_review',
+      }),
+      expect.objectContaining({
+        rank: 3,
+        run_id: 'RUN-103',
+        case_id: 'BUILD-001',
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workflow_version: 'wf-1',
+        total_score: 44,
+        status: 'fail',
+      }),
+    ]);
+    expect(report.failure_breakdown).toEqual({
+      total_runs: 3,
+      status_counts: {
+        pass: 1,
+        fail: 1,
+        needs_review: 1,
+      },
+      tagged_failures: [
+        { tag: 'F10', count: 2 },
+        { tag: 'F2', count: 1 },
+      ],
+      untagged_runs: 1,
+    });
+    expect(report.regression_diff).toMatchObject({
+      summary: {
+        matched_cases: 3,
+        regressions: 2,
+        improvements: 1,
+        unchanged: 0,
+        added_cases: 0,
+        removed_cases: 0,
+      },
+      entries: [
+        {
+          case_id: 'BUILD-001',
+          comparison_key: 'BUILD-001::codex-cli::gpt-5.4::wf-1',
+          classification: 'regressed',
+          score_delta: -14,
+          status_change: 'fail -> fail',
+          new_failures: ['F10'],
+          fixed_failures: [],
+        },
+        {
+          case_id: 'DISCOVER-001',
+          comparison_key: 'DISCOVER-001::codex-cli::gpt-5.4::wf-1',
+          classification: 'improved',
+          score_delta: 11,
+          status_change: 'pass -> pass',
+          new_failures: [],
+          fixed_failures: [],
+        },
+        {
+          case_id: 'DISCOVER-002',
+          comparison_key: 'DISCOVER-002::codex-cli::gpt-5.4::wf-1',
+          classification: 'regressed',
+          score_delta: -6,
+          status_change: 'pass -> needs_review',
+          new_failures: ['F10'],
+          fixed_failures: [],
+        },
+      ],
+    });
+
+    expect(markdown).toContain('# Benchmark Report');
+    expect(markdown).toContain('## Leaderboard');
+    expect(markdown).toContain('| 1 | DISCOVER-001 | RUN-101 | codex-cli | gpt-5.4 | wf-1 | pass | 91 |');
+    expect(markdown).toContain('## Failure Breakdown');
+    expect(markdown).toContain('| F10 | 2 |');
+    expect(markdown).toContain('## Regression Diff');
+    expect(markdown).toContain('| BUILD-001 | BASE-103 | RUN-103 | -14 | regressed | fail -> fail | F10 | - |');
+  });
+
+  it('keeps distinct regression entries for the same case across different run dimensions and detects failure-tag churn', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-A', {
+      case_id: 'DISCOVER-003',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-a',
+      total_score: 70,
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      human_review_required: true,
+    });
+    writeRunFixture(currentRoot, 'RUN-B', {
+      case_id: 'DISCOVER-003',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4-mini',
+      workflow_version: 'wf-a',
+      total_score: 70,
+      failure_tags: ['F2'],
+      primary_failure_tag: 'F2',
+      status: 'fail',
+      auto_verdict: 'fail',
+    });
+
+    writeRunFixture(baselineRoot, 'BASE-A', {
+      case_id: 'DISCOVER-003',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-a',
+      total_score: 70,
+      failure_tags: [],
+      primary_failure_tag: null,
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      human_review_required: true,
+    });
+    writeRunFixture(baselineRoot, 'BASE-B', {
+      case_id: 'DISCOVER-003',
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4-mini',
+      workflow_version: 'wf-a',
+      total_score: 70,
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      status: 'fail',
+      auto_verdict: 'fail',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.entries).toHaveLength(2);
+    expect(report.regression_diff.entries).toEqual([
+      expect.objectContaining({
+        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4-mini::wf-a',
+        classification: 'regressed',
+        new_failures: ['F2'],
+        fixed_failures: ['F10'],
+      }),
+      expect.objectContaining({
+        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4::wf-a',
+        classification: 'regressed',
+        new_failures: ['F10'],
+        fixed_failures: [],
+      }),
+    ]);
+  });
+
+  it('keeps regression diff empty when no baseline root is provided', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    cleanupPaths.push(currentRoot);
+
+    writeRunFixture(currentRoot, 'RUN-201', {
+      case_id: 'DISCOVER-004',
+      total_score: 88,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+    });
+
+    expect(report.baseline_root).toBeNull();
+    expect(report.regression_diff).toEqual({
+      summary: {
+        matched_cases: 0,
+        regressions: 0,
+        improvements: 0,
+        unchanged: 0,
+        added_cases: 0,
+        removed_cases: 0,
+      },
+      entries: [],
+    });
+    expect(buildMarkdownReport(report)).toContain('Added Cases: 0, Removed Cases: 0');
+  });
+});

--- a/tests/benchmark-reporter.test.ts
+++ b/tests/benchmark-reporter.test.ts
@@ -208,7 +208,7 @@ describe('benchmark reporter', () => {
       entries: [
         {
           case_id: 'BUILD-001',
-          comparison_key: 'BUILD-001::codex-cli::gpt-5.4::wf-1',
+          comparison_key: 'BUILD-001::codex-cli::gpt-5.4',
           classification: 'regressed',
           score_delta: -14,
           status_change: 'fail -> fail',
@@ -217,7 +217,7 @@ describe('benchmark reporter', () => {
         },
         {
           case_id: 'DISCOVER-001',
-          comparison_key: 'DISCOVER-001::codex-cli::gpt-5.4::wf-1',
+          comparison_key: 'DISCOVER-001::codex-cli::gpt-5.4',
           classification: 'improved',
           score_delta: 11,
           status_change: 'pass -> pass',
@@ -226,7 +226,7 @@ describe('benchmark reporter', () => {
         },
         {
           case_id: 'DISCOVER-002',
-          comparison_key: 'DISCOVER-002::codex-cli::gpt-5.4::wf-1',
+          comparison_key: 'DISCOVER-002::codex-cli::gpt-5.4',
           classification: 'regressed',
           score_delta: -6,
           status_change: 'pass -> needs_review',
@@ -306,16 +306,54 @@ describe('benchmark reporter', () => {
     expect(report.regression_diff.entries).toHaveLength(2);
     expect(report.regression_diff.entries).toEqual([
       expect.objectContaining({
-        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4-mini::wf-a',
+        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4',
+        classification: 'regressed',
+        new_failures: ['F10'],
+        fixed_failures: [],
+      }),
+      expect.objectContaining({
+        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4-mini',
         classification: 'regressed',
         new_failures: ['F2'],
         fixed_failures: ['F10'],
       }),
+    ]);
+  });
+
+  it('matches runs across workflow versions instead of downgrading them to added and removed entries', () => {
+    const currentRoot = makeTempDir('benchmark-current-');
+    const baselineRoot = makeTempDir('benchmark-baseline-');
+    cleanupPaths.push(currentRoot, baselineRoot);
+
+    writeRunFixture(currentRoot, 'RUN-301', {
+      case_id: 'DISCOVER-005',
+      workflow_version: 'wf-new',
+      total_score: 62,
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+      failure_tags: ['F10'],
+      primary_failure_tag: 'F10',
+      human_review_required: true,
+    });
+    writeRunFixture(baselineRoot, 'BASE-301', {
+      case_id: 'DISCOVER-005',
+      workflow_version: 'wf-old',
+      total_score: 78,
+      status: 'pass',
+      auto_verdict: 'pass',
+    });
+
+    const report = buildJsonReport({
+      runs_root: currentRoot,
+      baseline_root: baselineRoot,
+    });
+
+    expect(report.regression_diff.entries).toEqual([
       expect.objectContaining({
-        comparison_key: 'DISCOVER-003::codex-cli::gpt-5.4::wf-a',
+        comparison_key: 'DISCOVER-005::codex-cli::gpt-5.4',
         classification: 'regressed',
-        new_failures: ['F10'],
-        fixed_failures: [],
+        baseline_run_id: 'BASE-301',
+        current_run_id: 'RUN-301',
       }),
     ]);
   });

--- a/tests/benchmark-review-store.test.ts
+++ b/tests/benchmark-review-store.test.ts
@@ -1,0 +1,165 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  applyHumanReview,
+  createReviewTicket,
+} from '../src/benchmark/review-store.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function makeNeedsReviewRunDir(): string {
+  const runDir = makeTempDir('benchmark-review-store-');
+
+  mkdirSync(join(runDir, 'artifacts'), { recursive: true });
+  writeFileSync(join(runDir, 'transcript.jsonl'), '{"role":"assistant","content":"trace"}\n', 'utf-8');
+  writeJson(join(runDir, 'event-log.json'), {
+    status: 'complete',
+    warnings: ['trace_insufficient: cannot_determine_outcome'],
+  });
+  writeFileSync(join(runDir, 'artifacts', 'summary.txt'), 'artifact\n', 'utf-8');
+  writeJson(join(runDir, 'verdict.json'), {
+    status: 'needs_review',
+    auto_verdict: 'needs_review',
+    run_id: 'run-001',
+    total_score: 37,
+    score_breakdown: {
+      process_score: 32,
+      outcome_score: 0,
+      efficiency_score: 5,
+      counted_efficiency_score: 5,
+      efficiency_excluded: false,
+      process_fail: false,
+    },
+    failure_tags: ['F10'],
+    failure_tag_names: ['trace_insufficient'],
+    primary_failure_tag: 'F10',
+    human_review_required: true,
+    final_verdict: null,
+    review_reason: ['semantic_ambiguity'],
+    required_events_met: ['phase_entered:discover'],
+    trace_insufficient_reasons: ['cannot_determine_outcome'],
+    review_ticket: {
+      status: 'pending_review',
+      run_dir: runDir,
+      review_reason: ['semantic_ambiguity'],
+      failure_tags: ['F10'],
+      preserved_evidence: {
+        transcript: 'transcript.jsonl',
+        event_log: 'event-log.json',
+        artifacts: 'artifacts',
+      },
+    },
+  });
+
+  return runDir;
+}
+
+describe('review-store', () => {
+  it('writes a pending review record and resolves it without removing automatic evidence', () => {
+    const runDir = makeNeedsReviewRunDir();
+
+    const pending = createReviewTicket({
+      run_dir: runDir,
+      review_reason: ['semantic_ambiguity'],
+      failure_tags: ['F10'],
+    });
+
+    expect(pending).toMatchObject({
+      status: 'pending_review',
+      run_dir: runDir,
+      review_reason: ['semantic_ambiguity'],
+      failure_tags: ['F10'],
+      preserved_evidence: {
+        transcript: 'transcript.jsonl',
+        event_log: 'event-log.json',
+        artifacts: 'artifacts',
+      },
+      final_verdict: null,
+    });
+
+    const reviewRecordPath = join(runDir, 'review-record.json');
+    expect(existsSync(reviewRecordPath)).toBe(true);
+
+    const resolved = applyHumanReview({
+      run_dir: runDir,
+      final_verdict: 'pass',
+      reviewer: 'qa-user',
+      notes: 'Trace confirms expected behavior.',
+    });
+
+    expect(resolved.review_record).toMatchObject({
+      status: 'resolved',
+      run_dir: runDir,
+      review_reason: ['semantic_ambiguity'],
+      final_verdict: 'pass',
+      reviewed_by: 'qa-user',
+      notes: 'Trace confirms expected behavior.',
+    });
+    expect(resolved.verdict).toMatchObject({
+      status: 'pass',
+      auto_verdict: 'needs_review',
+      final_verdict: 'pass',
+      review_reason: ['semantic_ambiguity'],
+      review_ticket: {
+        status: 'pending_review',
+        run_dir: runDir,
+        review_reason: ['semantic_ambiguity'],
+        failure_tags: ['F10'],
+        preserved_evidence: {
+          transcript: 'transcript.jsonl',
+          event_log: 'event-log.json',
+          artifacts: 'artifacts',
+        },
+      },
+    });
+
+    const onDiskRecord = JSON.parse(readFileSync(reviewRecordPath, 'utf-8')) as unknown;
+    const onDiskVerdict = JSON.parse(readFileSync(join(runDir, 'verdict.json'), 'utf-8')) as unknown;
+
+    expect(onDiskRecord).toEqual(resolved.review_record);
+    expect(onDiskVerdict).toEqual(resolved.verdict);
+  });
+
+  it('rejects review ticket creation when the verdict is not reviewable', () => {
+    const runDir = makeTempDir('benchmark-review-store-');
+
+    writeJson(join(runDir, 'verdict.json'), {
+      status: 'pass',
+      auto_verdict: 'pass',
+      final_verdict: null,
+      review_reason: [],
+    });
+
+    expect(() => createReviewTicket({
+      run_dir: runDir,
+      review_reason: ['semantic_ambiguity'],
+      failure_tags: ['F10'],
+    })).toThrow('benchmark_review_not_required');
+  });
+});

--- a/tests/benchmark-runner.test.ts
+++ b/tests/benchmark-runner.test.ts
@@ -1,0 +1,394 @@
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createAdapterRegistry, type BenchmarkAdapter } from '../src/benchmark/adapter-registry.js';
+import { executeRunAdapter } from '../src/benchmark/adapter-runner.js';
+import { loadBenchmarkCase } from '../src/benchmark/case-loader.js';
+import { prepareRunWorkspace } from '../src/benchmark/fixture-workspace.js';
+import {
+  getPhase1RunProfile,
+  validateRunContract,
+} from '../src/benchmark/run-profile.js';
+import { type BenchmarkRunMetadata } from '../src/benchmark/types.js';
+import { writeStandardRunDirectory } from '../src/benchmark/run-writer.js';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function makeFakeAdapter(
+  override?: Partial<BenchmarkAdapter>,
+): BenchmarkAdapter {
+  return {
+    platform_id: 'codex-cli',
+    command: ['fake-codex'],
+    async run(request) {
+      const artifactPath = join(request.workspace_path, 'artifacts-source', 'adapter.log');
+      mkdirSync(join(request.workspace_path, 'artifacts-source'), { recursive: true });
+      writeFileSync(artifactPath, `adapter for ${request.platform_id}\n`, 'utf-8');
+
+      return {
+        exit_code: 0,
+        transcript_records: [
+          {
+            timestamp: '2026-04-09T00:00:00.000Z',
+            role: 'assistant',
+            event_type: 'message',
+            content: 'adapter completed',
+          },
+        ],
+        artifact_snapshot: [artifactPath],
+        adapter_notes: ['fake adapter'],
+      };
+    },
+    ...override,
+  };
+}
+
+describe('benchmark runner module', () => {
+  const benchmarkRoot = join(process.cwd(), 'benchmark');
+  const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+  const promptPath = join(caseDir, 'prompt.txt');
+
+  it('copies the synthetic fixture into a fresh workspace and writes a standard run directory', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const firstWorkspace = prepareRunWorkspace(bundle, 'RUN-001', projectRoot);
+    const secondWorkspace = prepareRunWorkspace(bundle, 'RUN-002', projectRoot);
+
+    writeFileSync(join(firstWorkspace.workspace_path, 'README.md'), 'mutated\n', 'utf-8');
+    expect(readFileSync(join(secondWorkspace.workspace_path, 'README.md'), 'utf-8')).toContain(
+      'DISCOVER-001',
+    );
+
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([makeFakeAdapter()]);
+    const adapterResult = await executeRunAdapter(
+      {
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workspace_path: secondWorkspace.workspace_path,
+        prompt_path: promptPath,
+        profile,
+        timeout_seconds: bundle.case.budget.timeout_seconds,
+      },
+      { registry },
+    );
+
+    const metadata: BenchmarkRunMetadata = {
+      run_id: 'RUN-002',
+      case_id: bundle.case.id,
+      case_version: bundle.case.case_version,
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-phase1',
+      repo_fixture_hash: bundle.fixture_hash,
+      trace_extractor_version: 'pending-mod005',
+      run_profile: profile.profile_id,
+    };
+
+    const runOutput = writeStandardRunDirectory(metadata, adapterResult, join(projectRoot, 'runs'));
+
+    expect(existsSync(join(runOutput.run_dir, 'metadata.json'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'transcript.jsonl'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'transcript.json'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'artifacts', 'artifacts-source', 'adapter.log'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'event-log.json'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'verdict.json'))).toBe(true);
+
+    const contract = validateRunContract(runOutput.run_dir, profile.profile_id);
+    expect(contract.valid).toBe(true);
+    expect(contract.metadata).toMatchObject({
+      case_id: bundle.case.id,
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+    });
+  });
+
+  it('rejects adapters that do not provide the required transcript fields', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-003', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([
+      makeFakeAdapter({
+        async run() {
+          return {
+            exit_code: 0,
+            transcript_records: [
+              {
+                timestamp: '2026-04-09T00:00:00.000Z',
+                role: 'assistant',
+                event_type: 'message',
+              },
+            ],
+            artifact_snapshot: [],
+            adapter_notes: [],
+          };
+        },
+      }),
+    ]);
+
+    await expect(
+      executeRunAdapter(
+        {
+          platform_id: 'codex-cli',
+          model_id: 'gpt-5.4',
+          workspace_path: workspace.workspace_path,
+          prompt_path: promptPath,
+          profile,
+          timeout_seconds: bundle.case.budget.timeout_seconds,
+        },
+        { registry },
+      ),
+    ).rejects.toMatchObject({
+      code: 'incomplete_run_contract',
+      details: {
+        missingTraceFields: ['content'],
+      },
+    });
+  });
+
+  it('rejects a standard run directory when required metadata is missing', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-004', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([makeFakeAdapter()]);
+    const adapterResult = await executeRunAdapter(
+      {
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workspace_path: workspace.workspace_path,
+        prompt_path: promptPath,
+        profile,
+        timeout_seconds: bundle.case.budget.timeout_seconds,
+      },
+      { registry },
+    );
+
+    const invalidMetadata = {
+      run_id: 'RUN-004',
+      case_id: bundle.case.id,
+      case_version: bundle.case.case_version,
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-phase1',
+      repo_fixture_hash: bundle.fixture_hash,
+      run_profile: profile.profile_id,
+    } as BenchmarkRunMetadata;
+
+    try {
+      writeStandardRunDirectory(invalidMetadata, adapterResult, join(projectRoot, 'runs'));
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'incomplete_run_contract',
+        details: {
+          missingFields: ['trace_extractor_version'],
+        },
+      });
+    }
+  });
+
+  it('preserves nested artifact snapshot paths inside the standard run directory', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-006', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([
+      makeFakeAdapter({
+        async run(request) {
+          const nestedArtifactPath = join(
+            request.workspace_path,
+            'artifacts-source',
+            'logs',
+            'adapter.log',
+          );
+          const reportPath = join(
+            request.workspace_path,
+            'artifacts-source',
+            'reports',
+            'result.json',
+          );
+
+          mkdirSync(join(request.workspace_path, 'artifacts-source', 'logs'), { recursive: true });
+          mkdirSync(join(request.workspace_path, 'artifacts-source', 'reports'), { recursive: true });
+          writeFileSync(nestedArtifactPath, 'nested log\n', 'utf-8');
+          writeFileSync(reportPath, '{"ok":true}\n', 'utf-8');
+
+          return {
+            exit_code: 0,
+            transcript_records: [
+              {
+                timestamp: '2026-04-09T00:00:00.000Z',
+                role: 'assistant',
+                event_type: 'message',
+                content: 'adapter completed',
+              },
+            ],
+            artifact_snapshot: [
+              'artifacts-source/logs/adapter.log',
+              'artifacts-source/reports/result.json',
+            ],
+            adapter_notes: ['fake adapter'],
+          };
+        },
+      }),
+    ]);
+
+    const adapterResult = await executeRunAdapter(
+      {
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workspace_path: workspace.workspace_path,
+        prompt_path: promptPath,
+        profile,
+        timeout_seconds: bundle.case.budget.timeout_seconds,
+      },
+      { registry },
+    );
+
+    const metadata: BenchmarkRunMetadata = {
+      run_id: 'RUN-006',
+      case_id: bundle.case.id,
+      case_version: bundle.case.case_version,
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-phase1',
+      repo_fixture_hash: bundle.fixture_hash,
+      trace_extractor_version: 'pending-mod005',
+      run_profile: profile.profile_id,
+    };
+
+    const runOutput = writeStandardRunDirectory(metadata, adapterResult, join(projectRoot, 'runs'));
+
+    expect(existsSync(join(runOutput.run_dir, 'artifacts', 'artifacts-source', 'logs', 'adapter.log'))).toBe(true);
+    expect(existsSync(join(runOutput.run_dir, 'artifacts', 'artifacts-source', 'reports', 'result.json'))).toBe(true);
+  });
+
+  it('rejects unknown adapter platforms before execution', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-005', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+
+    await expect(
+      executeRunAdapter({
+        platform_id: 'unknown-cli',
+        model_id: 'gpt-5.4',
+        workspace_path: workspace.workspace_path,
+        prompt_path: promptPath,
+        profile,
+        timeout_seconds: bundle.case.budget.timeout_seconds,
+      }),
+    ).rejects.toMatchObject({
+      code: 'adapter_missing',
+    });
+  });
+
+  it('rejects adapters that provide no transcript output instead of fabricating trace evidence', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-007', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([
+      makeFakeAdapter({
+        async run() {
+          return {
+            exit_code: 0,
+            transcript_records: [],
+            artifact_snapshot: [],
+            adapter_notes: [],
+          };
+        },
+      }),
+    ]);
+
+    await expect(
+      executeRunAdapter(
+        {
+          platform_id: 'codex-cli',
+          model_id: 'gpt-5.4',
+          workspace_path: workspace.workspace_path,
+          prompt_path: promptPath,
+          profile,
+          timeout_seconds: bundle.case.budget.timeout_seconds,
+        },
+        { registry },
+      ),
+    ).rejects.toMatchObject({
+      code: 'incomplete_run_contract',
+      details: {
+        missingTraceFields: profile.transcript_record_fields,
+      },
+    });
+  });
+
+  it('rejects run ids that attempt to escape the benchmark output root', async () => {
+    const bundle = loadBenchmarkCase(caseDir);
+    const projectRoot = makeTempDir('benchmark-project-');
+    cleanupPaths.push(projectRoot);
+
+    expect(() => prepareRunWorkspace(bundle, '../escape', projectRoot)).toThrow('invalid_run_id');
+
+    const workspace = prepareRunWorkspace(bundle, 'RUN-008', projectRoot);
+    const profile = getPhase1RunProfile(bundle.case.run_profile);
+    const registry = createAdapterRegistry([makeFakeAdapter()]);
+    const adapterResult = await executeRunAdapter(
+      {
+        platform_id: 'codex-cli',
+        model_id: 'gpt-5.4',
+        workspace_path: workspace.workspace_path,
+        prompt_path: promptPath,
+        profile,
+        timeout_seconds: bundle.case.budget.timeout_seconds,
+      },
+      { registry },
+    );
+
+    const metadata = {
+      run_id: '../escape',
+      case_id: bundle.case.id,
+      case_version: bundle.case.case_version,
+      platform_id: 'codex-cli',
+      model_id: 'gpt-5.4',
+      workflow_version: 'wf-phase1',
+      repo_fixture_hash: bundle.fixture_hash,
+      trace_extractor_version: 'pending-mod005',
+      run_profile: profile.profile_id,
+    } as BenchmarkRunMetadata;
+
+    expect(() => writeStandardRunDirectory(metadata, adapterResult, join(projectRoot, 'runs'))).toThrow(
+      'run_id must stay within the benchmark output root',
+    );
+  });
+});

--- a/tests/benchmark-suite-manifest.test.ts
+++ b/tests/benchmark-suite-manifest.test.ts
@@ -1,0 +1,213 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  loadSuiteManifest,
+  resolveCaseSelector,
+} from '../src/benchmark/suite-manifest.js';
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function writeSyntheticCase(benchmarkRoot: string, caseId: string): void {
+  const caseDir = join(benchmarkRoot, 'cases', caseId);
+  mkdirSync(join(caseDir, 'fixture'), { recursive: true });
+  writeJson(join(caseDir, 'case.json'), {
+    id: caseId,
+    case_version: '2026-04-09',
+    run_profile: 'phase1-local-cli-v1',
+    fixture: 'fixture',
+    budget: {
+      max_turns: 6,
+      timeout_seconds: 180,
+      max_cost_usd: 3,
+    },
+  });
+  writeFileSync(join(caseDir, 'prompt.txt'), `Run synthetic case ${caseId}.\n`, 'utf-8');
+  writeJson(join(caseDir, 'oracle.json'), {
+    verdict: 'pass',
+    checks: ['build', 'tests'],
+  });
+  writeFileSync(join(caseDir, 'fixture', 'README.md'), `# ${caseId}\n`, 'utf-8');
+}
+
+function writePhase1Manifest(
+  benchmarkRoot: string,
+  overrides: Partial<{
+    suite_id: string;
+    case_ids: string[];
+    profile_id: string;
+    ranked_platform_ids: string[];
+    ranked_platform_admission_rule: string;
+    platform_admissions: Record<string, { profile_id: string; stable_full_trace: boolean }>;
+  }> = {},
+): void {
+  mkdirSync(join(benchmarkRoot, 'suites'), { recursive: true });
+  writeJson(join(benchmarkRoot, 'suites', 'phase1.json'), {
+    suite_id: 'phase1',
+    case_ids: [
+      'DISCOVER-001',
+      'DISCOVER-002',
+      'DISCOVER-003',
+      'DISCOVER-004',
+      'DISCOVER-005',
+      'SPEC-001',
+      'SPEC-002',
+      'BUILD-001',
+      'BUILD-002',
+      'BUILD-003',
+    ],
+    profile_id: 'phase1-local-cli-v1',
+    ranked_platform_ids: ['codex-cli'],
+    ranked_platform_admission_rule: 'Only platforms with stable complete trace evidence under phase1-local-cli-v1 may be ranked.',
+    platform_admissions: {
+      'codex-cli': {
+        profile_id: 'phase1-local-cli-v1',
+        stable_full_trace: true,
+      },
+    },
+    ...overrides,
+  });
+}
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe('loadSuiteManifest', () => {
+  it('loads the official phase1 suite and preserves the fixed run profile', () => {
+    const suite = loadSuiteManifest('phase1');
+
+    expect(suite.suite_id).toBe('phase1');
+    expect(suite.minimum_case_count).toBe(10);
+    expect(suite.profile_id).toBe('phase1-local-cli-v1');
+    expect(suite.case_ids.length).toBeGreaterThanOrEqual(10);
+    expect(suite.ranked_platform_ids).toEqual(['codex-cli']);
+    expect(suite.ranked_platform_admission_rule).toContain('stable complete trace evidence');
+  });
+
+  it('rejects the official suite when the manifest falls under the minimum case count', () => {
+    const benchmarkRoot = makeTempDir('benchmark-root-');
+    cleanupPaths.push(benchmarkRoot);
+
+    writePhase1Manifest(benchmarkRoot, {
+      case_ids: [
+        'DISCOVER-001',
+        'DISCOVER-002',
+        'DISCOVER-003',
+        'DISCOVER-004',
+        'DISCOVER-005',
+        'SPEC-001',
+        'SPEC-002',
+        'BUILD-001',
+        'BUILD-002',
+      ],
+    });
+
+    try {
+      loadSuiteManifest('phase1', benchmarkRoot);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'suite_under_minimum',
+      });
+    }
+  });
+
+  it('rejects ranked platforms that are missing phase1 full-trace admission', () => {
+    const benchmarkRoot = makeTempDir('benchmark-root-');
+    cleanupPaths.push(benchmarkRoot);
+
+    writePhase1Manifest(benchmarkRoot, {
+      platform_admissions: {
+        'codex-cli': {
+          profile_id: 'phase1-local-cli-v1',
+          stable_full_trace: false,
+        },
+      },
+    });
+
+    try {
+      loadSuiteManifest('phase1', benchmarkRoot);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'ranked_platform_missing_admission',
+      });
+    }
+  });
+});
+
+describe('resolveCaseSelector', () => {
+  const repoBenchmarkRoot = join(process.cwd(), 'benchmark');
+
+  it('resolves the phase1 suite selector into concrete case directories', () => {
+    const caseDirs = resolveCaseSelector('phase1', repoBenchmarkRoot);
+
+    expect(caseDirs.length).toBeGreaterThanOrEqual(10);
+    expect(caseDirs.every((caseDir) => isAbsolute(caseDir))).toBe(true);
+    expect(caseDirs[0]).toContain(join('benchmark', 'cases'));
+  });
+
+  it('resolves a single case id into its in-repo case directory', () => {
+    const caseDirs = resolveCaseSelector('DISCOVER-001', repoBenchmarkRoot);
+
+    expect(caseDirs).toEqual([join(repoBenchmarkRoot, 'cases', 'DISCOVER-001')]);
+  });
+
+  it('accepts an explicit case path inside the benchmark root', () => {
+    const benchmarkRoot = makeTempDir('benchmark-root-');
+    cleanupPaths.push(benchmarkRoot);
+
+    writeSyntheticCase(benchmarkRoot, 'CASE-LOCAL-001');
+
+    const caseDir = join(benchmarkRoot, 'cases', 'CASE-LOCAL-001');
+    const caseDirs = resolveCaseSelector(caseDir, benchmarkRoot);
+
+    expect(caseDirs).toEqual([caseDir]);
+  });
+
+  it('rejects explicit case paths outside the benchmark root', () => {
+    const benchmarkRoot = makeTempDir('benchmark-root-');
+    const externalCaseDir = makeTempDir('benchmark-external-');
+    cleanupPaths.push(benchmarkRoot, externalCaseDir);
+
+    try {
+      resolveCaseSelector(externalCaseDir, benchmarkRoot);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'case_path_outside_suite_root',
+      });
+    }
+  });
+
+  it('rejects unknown selectors', () => {
+    const benchmarkRoot = makeTempDir('benchmark-root-');
+    cleanupPaths.push(benchmarkRoot);
+
+    try {
+      resolveCaseSelector('UNKNOWN-CASE', benchmarkRoot);
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: 'case_selector_unknown',
+      });
+    }
+  });
+});

--- a/tests/benchmark-trace.test.ts
+++ b/tests/benchmark-trace.test.ts
@@ -1,0 +1,287 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  extractObservationEvents,
+  type BenchmarkArtifactChange,
+  type BenchmarkTranscriptRecord,
+} from '../src/benchmark/trace-extractor.js';
+import { deriveSemanticEvents } from '../src/benchmark/semantic-mapper.js';
+import { writeEventLog } from '../src/benchmark/event-log-writer.js';
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const Ajv2020 = require('ajv/dist/2020');
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanupPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function makeTranscript(): BenchmarkTranscriptRecord[] {
+  return [
+    {
+      timestamp: '2026-04-09T10:00:00.000Z',
+      role: 'assistant',
+      event_type: 'message',
+      content: 'Entering discover phase.',
+    },
+    {
+      timestamp: '2026-04-09T10:01:00.000Z',
+      role: 'assistant',
+      event_type: 'tool_call',
+      content: 'Dispatching independent critic review.',
+      tool_name: 'critic',
+    },
+    {
+      timestamp: '2026-04-09T10:02:00.000Z',
+      role: 'assistant',
+      event_type: 'tool_result',
+      content: 'Re-ran npm test after applying fixes.',
+      tool_name: 'npm test',
+    },
+  ];
+}
+
+function makeArtifacts(): BenchmarkArtifactChange[] {
+  return [
+    {
+      timestamp: '2026-04-09T10:02:30.000Z',
+      path: 'artifacts/verdict.json',
+      change_type: 'modified',
+    },
+  ];
+}
+
+describe('extractObservationEvents', () => {
+  it('extracts observation events from transcript records and artifact changes', () => {
+    const observationEvents = extractObservationEvents({
+      transcript: makeTranscript(),
+      artifact_changes: makeArtifacts(),
+    });
+
+    expect(observationEvents).toHaveLength(4);
+    expect(observationEvents).toEqual([
+      expect.objectContaining({
+        id: 'obs-0001',
+        source: 'transcript',
+        type: 'phase_signal',
+        observation_key: 'phase_candidate',
+        observation_value: 'discover',
+      }),
+      expect.objectContaining({
+        id: 'obs-0002',
+        source: 'transcript',
+        type: 'review_signal',
+        observation_key: 'review_dispatch_candidate',
+        observation_value: 'critic',
+      }),
+      expect.objectContaining({
+        id: 'obs-0003',
+        source: 'transcript',
+        type: 'reverify_signal',
+        observation_key: 'reverify_candidate',
+        observation_value: 'npm test',
+      }),
+      expect.objectContaining({
+        id: 'obs-0004',
+        source: 'artifact',
+        type: 'artifact_change',
+        observation_key: 'artifact_modified',
+        observation_value: 'artifacts/verdict.json',
+      }),
+    ]);
+  });
+});
+
+describe('deriveSemanticEvents', () => {
+  it('derives phase entry, review dispatch, and fresh reverification from stable observation evidence', () => {
+    const observationEvents = extractObservationEvents({
+      transcript: makeTranscript(),
+      artifact_changes: makeArtifacts(),
+    });
+
+    const result = deriveSemanticEvents(observationEvents);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.semantic_events).toEqual([
+      expect.objectContaining({
+        type: 'phase_entered',
+        observation_event_ids: ['obs-0001'],
+        details: { phase: 'discover' },
+      }),
+      expect.objectContaining({
+        type: 'independent_review_dispatched',
+        observation_event_ids: ['obs-0002'],
+        details: { reviewer: 'critic' },
+      }),
+      expect.objectContaining({
+        type: 'fresh_reverification',
+        observation_event_ids: ['obs-0002', 'obs-0003', 'obs-0004'],
+        details: { tool: 'npm test' },
+      }),
+    ]);
+  });
+
+  it('emits trace_insufficient instead of guessing fresh reverification on ambiguous evidence', () => {
+    const result = deriveSemanticEvents([
+      {
+        id: 'obs-0001',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        source: 'transcript',
+        type: 'phase_signal',
+        observation_key: 'phase_candidate',
+        observation_value: 'discover',
+        evidence: {
+          content: 'Entering discover phase.',
+          transcript_index: 0,
+        },
+      },
+      {
+        id: 'obs-0002',
+        timestamp: '2026-04-09T10:01:00.000Z',
+        source: 'transcript',
+        type: 'review_signal',
+        observation_key: 'review_dispatch_candidate',
+        observation_value: 'critic',
+        evidence: {
+          content: 'Dispatching independent critic review.',
+          transcript_index: 1,
+        },
+      },
+    ]);
+
+    expect(result.semantic_events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'phase_entered',
+          observation_event_ids: ['obs-0001'],
+        }),
+        expect.objectContaining({
+          type: 'independent_review_dispatched',
+          observation_event_ids: ['obs-0002'],
+        }),
+      ]),
+    );
+    expect(result.warnings).toEqual(['trace_insufficient']);
+  });
+
+  it('emits trace_insufficient when artifact changes happen before the reverify signal', () => {
+    const result = deriveSemanticEvents([
+      {
+        id: 'obs-0001',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        source: 'transcript',
+        type: 'phase_signal',
+        observation_key: 'phase_candidate',
+        observation_value: 'discover',
+        evidence: {
+          content: 'Entering discover phase.',
+          transcript_index: 0,
+        },
+      },
+      {
+        id: 'obs-0002',
+        timestamp: '2026-04-09T10:01:00.000Z',
+        source: 'transcript',
+        type: 'review_signal',
+        observation_key: 'review_dispatch_candidate',
+        observation_value: 'critic',
+        evidence: {
+          content: 'Dispatching independent critic review.',
+          transcript_index: 1,
+        },
+      },
+      {
+        id: 'obs-0003',
+        timestamp: '2026-04-09T10:01:30.000Z',
+        source: 'artifact',
+        type: 'artifact_change',
+        observation_key: 'artifact_modified',
+        observation_value: 'artifacts/verdict.json',
+        evidence: {
+          path: 'artifacts/verdict.json',
+        },
+      },
+      {
+        id: 'obs-0004',
+        timestamp: '2026-04-09T10:02:00.000Z',
+        source: 'transcript',
+        type: 'reverify_signal',
+        observation_key: 'reverify_candidate',
+        observation_value: 'npm test',
+        evidence: {
+          content: 'Re-ran npm test after applying fixes.',
+          transcript_index: 2,
+        },
+      },
+    ]);
+
+    expect(result.semantic_events.some((event) => event.type === 'fresh_reverification')).toBe(false);
+    expect(result.warnings).toEqual(['trace_insufficient']);
+  });
+});
+
+describe('writeEventLog', () => {
+  it('writes a schema-valid event log and marks trace_insufficient when semantic evidence lacks observation ids', () => {
+    const outputDir = makeTempDir('benchmark-trace-');
+    const destinationPath = join(outputDir, 'event-log.json');
+    const observationEvents = extractObservationEvents({
+      transcript: makeTranscript(),
+      artifact_changes: makeArtifacts(),
+    });
+
+    const log = writeEventLog({
+      destination_path: destinationPath,
+      run_id: 'RUN-005',
+      observation_events: observationEvents,
+      semantic_events: [
+        {
+          id: 'sem-0001',
+          timestamp: '2026-04-09T10:00:00.000Z',
+          type: 'phase_entered',
+          observation_event_ids: ['obs-0001'],
+          details: { phase: 'discover' },
+        },
+        {
+          id: 'sem-0002',
+          timestamp: '2026-04-09T10:05:00.000Z',
+          type: 'fresh_reverification',
+          observation_event_ids: [],
+          details: { tool: 'npm test' },
+        },
+      ],
+      warnings: [],
+    });
+
+    expect(log.warnings).toEqual(['trace_insufficient']);
+    expect(log.semantic_events).toEqual([
+      expect.objectContaining({
+        id: 'sem-0001',
+        type: 'phase_entered',
+      }),
+    ]);
+
+    const persisted = JSON.parse(readFileSync(destinationPath, 'utf-8')) as unknown;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const schema = JSON.parse(readFileSync('schemas/benchmark-trace.schema.json', 'utf-8'));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const validate = ajv.compile(schema);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    expect(validate(persisted)).toBe(true);
+  });
+});

--- a/tests/benchmark-trace.test.ts
+++ b/tests/benchmark-trace.test.ts
@@ -177,6 +177,31 @@ describe('deriveSemanticEvents', () => {
     expect(result.warnings).toEqual(['trace_insufficient']);
   });
 
+  it('emits trace_insufficient when no independent review signal exists at all', () => {
+    const result = deriveSemanticEvents([
+      {
+        id: 'obs-0001',
+        timestamp: '2026-04-09T10:00:00.000Z',
+        source: 'transcript',
+        type: 'phase_signal',
+        observation_key: 'phase_candidate',
+        observation_value: 'discover',
+        evidence: {
+          content: 'Entering discover phase.',
+          transcript_index: 0,
+        },
+      },
+    ]);
+
+    expect(result.semantic_events).toEqual([
+      expect.objectContaining({
+        type: 'phase_entered',
+        observation_event_ids: ['obs-0001'],
+      }),
+    ]);
+    expect(result.warnings).toEqual(['trace_insufficient']);
+  });
+
   it('emits trace_insufficient when artifact changes happen before the reverify signal', () => {
     const result = deriveSemanticEvents([
       {

--- a/tests/nopilot-cli-benchmark.test.ts
+++ b/tests/nopilot-cli-benchmark.test.ts
@@ -90,6 +90,26 @@ function writeFakeCodexBin(binDir: string): void {
   chmodSync(codexPath, 0o755);
 }
 
+function writeFailingCodexBin(binDir: string): void {
+  mkdirSync(binDir, { recursive: true });
+  const codexPath = join(binDir, 'codex');
+  writeFileSync(
+    codexPath,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'printf "starting discover phase\\n"',
+      'printf "independent critic dispatch\\n"',
+      'printf "completed benchmark prompt\\n"',
+      'mkdir -p "$PWD/logs"',
+      'printf "{\\"result\\":\\"failed\\"}\\n" > "$PWD/logs/result.json"',
+      'exit 1',
+    ].join('\n'),
+    'utf-8',
+  );
+  chmodSync(codexPath, 0o755);
+}
+
 describe('nopilot benchmark CLI', () => {
   it('exposes the benchmark command group and its phase-1 subcommands', () => {
     ensureCliBuilt();
@@ -410,5 +430,68 @@ describe('nopilot benchmark CLI', () => {
       status: 'pass',
       final_verdict: 'pass',
     });
+  });
+
+  it('marks runs as failed when the adapter exits non-zero even if artifacts were produced', () => {
+    ensureCliBuilt();
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-exit-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'BUILD-001');
+
+    writeFailingCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli([
+      'benchmark', 'run', caseDir,
+      '--benchmark-root', benchmarkRoot,
+      '--platform', 'codex-cli',
+      '--model', 'gpt-5.4',
+      '--output-root', runsRoot,
+    ], { env });
+    expect(run.status).toBe(0);
+
+    const evaluate = runCli(['benchmark', 'evaluate', runsRoot, '--benchmark-root', benchmarkRoot], { env });
+    expect(evaluate.status).toBe(0);
+
+    const payload = JSON.parse(evaluate.stdout) as {
+      runs: Array<{ status: string; auto_verdict: string }>;
+    };
+    expect(payload.runs[0]).toMatchObject({
+      status: 'fail',
+      auto_verdict: 'fail',
+    });
+  });
+
+  it('rejects benchmark report before evaluate has replaced the pending verdict placeholder', () => {
+    ensureCliBuilt();
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-report-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli([
+      'benchmark', 'run', caseDir,
+      '--benchmark-root', benchmarkRoot,
+      '--platform', 'codex-cli',
+      '--model', 'gpt-5.4',
+      '--output-root', runsRoot,
+    ], { env });
+    expect(run.status).toBe(0);
+
+    const report = runCli(['benchmark', 'report', runsRoot], { env });
+    expect(report.status).toBe(1);
+    expect(report.stderr).toContain('benchmark_report_pending_evaluation');
   });
 });

--- a/tests/nopilot-cli-benchmark.test.ts
+++ b/tests/nopilot-cli-benchmark.test.ts
@@ -1,0 +1,297 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PACKAGE_ROOT = resolve(__dirname, '..');
+const CLI = resolve(PACKAGE_ROOT, 'dist', 'nopilot-cli.js');
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  for (const entry of cleanupPaths.splice(0)) {
+    rmSync(entry, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function runCli(
+  args: string[],
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
+): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: options.cwd ?? PACKAGE_ROOT,
+    encoding: 'utf-8',
+    env: { ...process.env, ...options.env },
+  });
+
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function writeFakeCodexBin(binDir: string): void {
+  mkdirSync(binDir, { recursive: true });
+  const codexPath = join(binDir, 'codex');
+  writeFileSync(
+    codexPath,
+    [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'printf "starting discover phase\\n"',
+      'printf "independent critic dispatch\\n"',
+      'printf "completed benchmark prompt\\n"',
+      'mkdir -p "$PWD/logs"',
+      'printf "{\\"result\\":\\"ok\\"}\\n" > "$PWD/logs/result.json"',
+    ].join('\n'),
+    'utf-8',
+  );
+  chmodSync(codexPath, 0o755);
+}
+
+describe('nopilot benchmark CLI', () => {
+  it('exposes the benchmark command group and its phase-1 subcommands', () => {
+    const result = runCli(['benchmark', '--help']);
+    const output = result.stdout + result.stderr;
+
+    expect(result.status).toBe(0);
+    expect(output).toContain('benchmark');
+    expect(output).toContain('validate-case');
+    expect(output).toContain('run');
+    expect(output).toContain('evaluate');
+    expect(output).toContain('report');
+    expect(output).toContain('review-apply');
+  });
+
+  it('runs a case through validate, run, evaluate, report, and review-apply', () => {
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const validate = runCli(
+      ['benchmark', 'validate-case', caseDir, '--benchmark-root', benchmarkRoot],
+      { env },
+    );
+    expect(validate.status).toBe(0);
+    expect(JSON.parse(validate.stdout)).toMatchObject({
+      command_group: 'benchmark',
+      subcommand: 'validate-case',
+      cases: [
+        {
+          case_id: 'DISCOVER-001',
+          case_version: '2026-04-09',
+          run_profile: 'phase1-local-cli-v1',
+        },
+      ],
+    });
+
+    const run = runCli(
+      [
+        'benchmark',
+        'run',
+        caseDir,
+        '--benchmark-root',
+        benchmarkRoot,
+        '--platform',
+        'codex-cli',
+        '--model',
+        'gpt-5.4',
+        '--output-root',
+        runsRoot,
+      ],
+      { env },
+    );
+    expect(run.status).toBe(0);
+
+    const runPayload = JSON.parse(run.stdout) as {
+      runs: Array<{
+        case_id: string;
+        run_dir: string;
+      }>;
+    };
+    expect(runPayload.runs).toHaveLength(1);
+    expect(runPayload.runs[0].case_id).toBe('DISCOVER-001');
+    expect(existsSync(join(runPayload.runs[0].run_dir, 'metadata.json'))).toBe(true);
+    expect(existsSync(join(runPayload.runs[0].run_dir, 'artifacts', 'logs', 'result.json'))).toBe(true);
+
+    const evaluate = runCli(
+      [
+        'benchmark',
+        'evaluate',
+        runsRoot,
+        '--benchmark-root',
+        benchmarkRoot,
+      ],
+      { env },
+    );
+    expect(evaluate.status).toBe(0);
+    expect(JSON.parse(evaluate.stdout)).toMatchObject({
+      command_group: 'benchmark',
+      subcommand: 'evaluate',
+      runs: [
+        {
+          case_id: 'DISCOVER-001',
+          status: 'needs_review',
+          auto_verdict: 'needs_review',
+        },
+      ],
+    });
+
+    const runDir = runPayload.runs[0].run_dir;
+    const verdictAfterEvaluate = JSON.parse(
+      readFileSync(join(runDir, 'verdict.json'), 'utf-8'),
+    ) as { status: string; review_ticket?: { preserved_evidence: Record<string, string> } };
+    expect(verdictAfterEvaluate.status).toBe('needs_review');
+    expect(verdictAfterEvaluate.review_ticket?.preserved_evidence).toEqual({
+      transcript: 'transcript.jsonl',
+      event_log: 'event-log.json',
+      artifacts: 'artifacts',
+    });
+
+    const report = runCli(
+      [
+        'benchmark',
+        'report',
+        runsRoot,
+      ],
+      { env },
+    );
+    expect(report.status).toBe(0);
+    expect(JSON.parse(report.stdout)).toMatchObject({
+      command_group: 'benchmark',
+      subcommand: 'report',
+      json_report_path: join(runsRoot, 'report.json'),
+      markdown_report_path: join(runsRoot, 'report.md'),
+    });
+    expect(readFileSync(join(runsRoot, 'report.md'), 'utf-8')).toContain('## Leaderboard');
+
+    const reviewApply = runCli(
+      [
+        'benchmark',
+        'review-apply',
+        runDir,
+        '--verdict',
+        'pass',
+        '--reviewer',
+        'qa-user',
+        '--notes',
+        'Manual review confirmed expected behavior.',
+      ],
+      { env },
+    );
+    expect(reviewApply.status).toBe(0);
+    expect(JSON.parse(reviewApply.stdout)).toMatchObject({
+      command_group: 'benchmark',
+      subcommand: 'review-apply',
+      run_dir: runDir,
+      final_verdict: 'pass',
+    });
+
+    const finalVerdict = JSON.parse(
+      readFileSync(join(runDir, 'verdict.json'), 'utf-8'),
+    ) as { status: string; final_verdict: string; human_review?: { reviewed_by: string } };
+    expect(finalVerdict).toMatchObject({
+      status: 'pass',
+      final_verdict: 'pass',
+      human_review: {
+        reviewed_by: 'qa-user',
+      },
+    });
+  });
+
+  it('does not mark evaluate as pass when oracle checks cannot be satisfied from the run evidence', () => {
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-fail-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli(
+      [
+        'benchmark',
+        'run',
+        caseDir,
+        '--benchmark-root',
+        benchmarkRoot,
+        '--platform',
+        'codex-cli',
+        '--model',
+        'gpt-5.4',
+        '--output-root',
+        runsRoot,
+      ],
+      { env },
+    );
+    expect(run.status).toBe(0);
+
+    const runPayload = JSON.parse(run.stdout) as {
+      runs: Array<{ run_dir: string }>;
+    };
+
+    const runDir = runPayload.runs[0].run_dir;
+    rmSync(join(runDir, 'artifacts', 'logs', 'result.json'), { force: true });
+
+    const evaluate = runCli(
+      [
+        'benchmark',
+        'evaluate',
+        runsRoot,
+        '--benchmark-root',
+        benchmarkRoot,
+      ],
+      { env },
+    );
+    expect(evaluate.status).toBe(0);
+
+    const evaluatePayload = JSON.parse(evaluate.stdout) as {
+      runs: Array<{ status: string; auto_verdict: string; review_reason: string[] }>;
+    };
+    expect(evaluatePayload.runs[0]).toMatchObject({
+      status: 'needs_review',
+      auto_verdict: 'needs_review',
+    });
+    expect(evaluatePayload.runs[0].review_reason).toEqual(
+      expect.arrayContaining([
+        'semantic_ambiguity',
+        'unknown_oracle_check:contract',
+        'unknown_oracle_check:trace',
+      ]),
+    );
+  });
+});

--- a/tests/nopilot-cli-benchmark.test.ts
+++ b/tests/nopilot-cli-benchmark.test.ts
@@ -310,10 +310,45 @@ describe('nopilot benchmark CLI', () => {
     });
     expect(evaluatePayload.runs[0].review_reason).toEqual(
       expect.arrayContaining([
-        'semantic_ambiguity',
         'oracle_trace_check_unverifiable',
       ]),
     );
+  });
+
+  it('keeps contract-valid runs from failing just because build-specific artifacts are absent', () => {
+    ensureCliBuilt();
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-contract-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli([
+      'benchmark', 'run', caseDir,
+      '--benchmark-root', benchmarkRoot,
+      '--platform', 'codex-cli',
+      '--model', 'gpt-5.4',
+      '--output-root', runsRoot,
+    ], { env });
+    expect(run.status).toBe(0);
+
+    const runDir = (JSON.parse(run.stdout) as { runs: Array<{ run_dir: string }> }).runs[0].run_dir;
+    rmSync(join(runDir, 'artifacts', 'logs', 'result.json'), { force: true });
+
+    const evaluate = runCli(['benchmark', 'evaluate', runsRoot, '--benchmark-root', benchmarkRoot], { env });
+    expect(evaluate.status).toBe(0);
+
+    const payload = JSON.parse(evaluate.stdout) as {
+      runs: Array<{ status: string; review_reason: string[] }>;
+    };
+    expect(payload.runs[0].status).toBe('needs_review');
+    expect(payload.runs[0].review_reason).not.toContain('unknown_oracle_check:contract');
   });
 
   it('preserves a resolved human review when evaluate is run again on the same run root', () => {

--- a/tests/nopilot-cli-benchmark.test.ts
+++ b/tests/nopilot-cli-benchmark.test.ts
@@ -17,6 +17,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PACKAGE_ROOT = resolve(__dirname, '..');
 const CLI = resolve(PACKAGE_ROOT, 'dist', 'nopilot-cli.js');
+let cliBuilt = false;
 
 const cleanupPaths: string[] = [];
 
@@ -52,6 +53,24 @@ function runCli(
   };
 }
 
+function ensureCliBuilt(): void {
+  if (cliBuilt && existsSync(CLI)) {
+    return;
+  }
+
+  const result = spawnSync('pnpm', ['build'], {
+    cwd: PACKAGE_ROOT,
+    encoding: 'utf-8',
+    env: process.env,
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`failed to build benchmark CLI test fixture: ${result.stderr ?? result.stdout}`);
+  }
+
+  cliBuilt = true;
+}
+
 function writeFakeCodexBin(binDir: string): void {
   mkdirSync(binDir, { recursive: true });
   const codexPath = join(binDir, 'codex');
@@ -73,6 +92,7 @@ function writeFakeCodexBin(binDir: string): void {
 
 describe('nopilot benchmark CLI', () => {
   it('exposes the benchmark command group and its phase-1 subcommands', () => {
+    ensureCliBuilt();
     const result = runCli(['benchmark', '--help']);
     const output = result.stdout + result.stderr;
 
@@ -86,6 +106,7 @@ describe('nopilot benchmark CLI', () => {
   });
 
   it('runs a case through validate, run, evaluate, report, and review-apply', () => {
+    ensureCliBuilt();
     const tmpRoot = makeTempDir('nopilot-benchmark-cli-');
     const binDir = join(tmpRoot, 'bin');
     const runsRoot = join(tmpRoot, 'runs');
@@ -230,6 +251,7 @@ describe('nopilot benchmark CLI', () => {
   });
 
   it('does not mark evaluate as pass when oracle checks cannot be satisfied from the run evidence', () => {
+    ensureCliBuilt();
     const tmpRoot = makeTempDir('nopilot-benchmark-cli-fail-');
     const binDir = join(tmpRoot, 'bin');
     const runsRoot = join(tmpRoot, 'runs');
@@ -289,9 +311,69 @@ describe('nopilot benchmark CLI', () => {
     expect(evaluatePayload.runs[0].review_reason).toEqual(
       expect.arrayContaining([
         'semantic_ambiguity',
-        'unknown_oracle_check:contract',
-        'unknown_oracle_check:trace',
+        'oracle_trace_check_unverifiable',
       ]),
     );
+  });
+
+  it('preserves a resolved human review when evaluate is run again on the same run root', () => {
+    ensureCliBuilt();
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-rerun-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'DISCOVER-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli(
+      [
+        'benchmark',
+        'run',
+        caseDir,
+        '--benchmark-root',
+        benchmarkRoot,
+        '--platform',
+        'codex-cli',
+        '--model',
+        'gpt-5.4',
+        '--output-root',
+        runsRoot,
+      ],
+      { env },
+    );
+    expect(run.status).toBe(0);
+
+    const runPayload = JSON.parse(run.stdout) as {
+      runs: Array<{ run_dir: string }>;
+    };
+    const runDir = runPayload.runs[0].run_dir;
+
+    expect(runCli(['benchmark', 'evaluate', runsRoot, '--benchmark-root', benchmarkRoot], { env }).status).toBe(0);
+    expect(runCli([
+      'benchmark',
+      'review-apply',
+      runDir,
+      '--verdict',
+      'pass',
+      '--reviewer',
+      'qa-user',
+    ], { env }).status).toBe(0);
+
+    const reevaluate = runCli(['benchmark', 'evaluate', runsRoot, '--benchmark-root', benchmarkRoot], { env });
+    expect(reevaluate.status).toBe(0);
+
+    const finalVerdict = JSON.parse(readFileSync(join(runDir, 'verdict.json'), 'utf-8')) as {
+      status: string;
+      final_verdict: string | null;
+    };
+    expect(finalVerdict).toMatchObject({
+      status: 'pass',
+      final_verdict: 'pass',
+    });
   });
 });

--- a/tests/nopilot-cli-benchmark.test.ts
+++ b/tests/nopilot-cli-benchmark.test.ts
@@ -494,4 +494,44 @@ describe('nopilot benchmark CLI', () => {
     expect(report.status).toBe(1);
     expect(report.stderr).toContain('benchmark_report_pending_evaluation');
   });
+
+  it('keeps SPEC cases in needs_review when spec artifacts exist but fresh reverification evidence is missing', () => {
+    ensureCliBuilt();
+    const tmpRoot = makeTempDir('nopilot-benchmark-cli-spec-');
+    const binDir = join(tmpRoot, 'bin');
+    const runsRoot = join(tmpRoot, 'runs');
+    const benchmarkRoot = join(PACKAGE_ROOT, 'benchmark');
+    const caseDir = join(benchmarkRoot, 'cases', 'SPEC-001');
+
+    writeFakeCodexBin(binDir);
+
+    const env = {
+      PATH: `${binDir}:${process.env.PATH ?? ''}`,
+    };
+
+    const run = runCli([
+      'benchmark', 'run', caseDir,
+      '--benchmark-root', benchmarkRoot,
+      '--platform', 'codex-cli',
+      '--model', 'gpt-5.4',
+      '--output-root', runsRoot,
+    ], { env });
+    expect(run.status).toBe(0);
+
+    const runPayload = JSON.parse(run.stdout) as { runs: Array<{ run_dir: string }> };
+    const runDir = runPayload.runs[0].run_dir;
+    mkdirSync(join(runDir, 'artifacts', 'spec'), { recursive: true });
+    writeFileSync(join(runDir, 'artifacts', 'spec', 'index.json'), '{"ok":true}\n', 'utf-8');
+
+    const evaluate = runCli(['benchmark', 'evaluate', runsRoot, '--benchmark-root', benchmarkRoot], { env });
+    expect(evaluate.status).toBe(0);
+
+    const payload = JSON.parse(evaluate.stdout) as {
+      runs: Array<{ status: string; review_reason: string[] }>;
+    };
+    expect(payload.runs[0].status).toBe('needs_review');
+    expect(payload.runs[0].review_reason).toEqual(
+      expect.arrayContaining(['oracle_spec_check_unverifiable']),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add the phase-1 benchmark subsystem across contracts, suite catalog, runner, trace pipeline, evaluator, review store, reporting, and framework CLI integration
- ship a synthetic benchmark suite plus local benchmark commands for validate-case, run, evaluate, report, and review-apply workflows
- cover the new benchmark flow with focused module tests and an end-to-end benchmark CLI test

## Verification
- pnpm test tests/benchmark-contracts.test.ts tests/benchmark-suite-manifest.test.ts tests/benchmark-runner.test.ts tests/benchmark-trace.test.ts tests/benchmark-evaluation.test.ts tests/benchmark-review-store.test.ts tests/benchmark-reporter.test.ts tests/nopilot-cli-benchmark.test.ts
- pnpm lint
- pnpm build
- pnpm test