### PR TITLE
fix: stabilize lash codex worktree execution

### DIFF
--- a/docs/lash-design-decisions.md
+++ b/docs/lash-design-decisions.md
@@ -48,7 +48,7 @@ Lash's architecture is grounded in five core principles:
 
 Lash uses **thin per-platform launchers** (not deep adapters):
 - CC: `claude -p <task> --session-id <uuid> --permission-mode bypassPermissions --append-system-prompt-file .lash/worker-instructions.md`
-- Codex: `codex exec -c approval_policy=auto-edit <task>`
+- Codex: `codex exec --full-auto -c system_prompt_file=.lash/worker-instructions.md <task>`
 - OpenCode: `opencode run <task> --agent coder`
 
 **Rationale**: Adding a new platform costs hours (write CLI wrapper), not weeks. Version updates to platform CLIs are localized to launcher constants.
@@ -305,4 +305,3 @@ Lash **replaces** NoPilot's `/build` phase:
 - Acceptance criteria verification via EARS model
 - State machine transitions per workflow.json
 - Backtrack triggers: spec_interface_infeasible (→BACKTRACK_SPEC), requirement_level_fundamental_issue (→BACKTRACK_DISCOVER)
-

--- a/src/lash/platform-launcher.ts
+++ b/src/lash/platform-launcher.ts
@@ -259,11 +259,11 @@ export function spawnWorker(
       ];
     }
   } else if (platform === 'codex') {
-    cmd = [
-      'codex', 'exec',
-      '-c', 'approval_policy=auto-edit',
-      task,
-    ];
+    cmd = ['codex', 'exec', '--full-auto'];
+    if (instructionFile) {
+      cmd.push('-c', `system_prompt_file=${instructionFile}`);
+    }
+    cmd.push(task);
   } else if (platform === 'opencode') {
     cmd = [
       'opencode', 'run', task,

--- a/src/lash/task-packager.ts
+++ b/src/lash/task-packager.ts
@@ -423,7 +423,7 @@ Launch this Worker with:
 
 Launch this Worker with:
 
-    codex exec -c approval_policy=auto-edit -c system_prompt_file=.lash/worker-instructions.md <task>
+    codex exec --full-auto -c system_prompt_file=.lash/worker-instructions.md <task>
 `;
   } else {
     // opencode — content is prepended to task prompt

--- a/src/lash/worktree-manager.ts
+++ b/src/lash/worktree-manager.ts
@@ -3,7 +3,7 @@
  * Translated from Python lash/worktree_manager.py.
  */
 import { execFile } from 'node:child_process';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { existsSync, symlinkSync } from 'node:fs';
 import type { MergeResult, WorktreeInfo, PreserveResult, UnexpectedFilesResult } from './types.js';
@@ -96,7 +96,7 @@ export async function createWorktree(moduleId: string, projectRoot: string = '.'
   }
 
   // Symlink node_modules from main repo — worktrees lack it (gitignored). (#37)
-  const srcModules = join(projectRoot, 'node_modules');
+  const srcModules = resolve(projectRoot, 'node_modules');
   const destModules = join(path, 'node_modules');
   if (existsSync(srcModules) && !existsSync(destModules)) {
     symlinkSync(srcModules, destModules, 'dir');
@@ -222,7 +222,7 @@ export async function createConflictResolutionWorktree(
   }
 
   // Symlink node_modules from main repo (#37)
-  const srcModules = join(projectRoot, 'node_modules');
+  const srcModules = resolve(projectRoot, 'node_modules');
   const destModules = join(path, 'node_modules');
   if (existsSync(srcModules) && !existsSync(destModules)) {
     symlinkSync(srcModules, destModules, 'dir');

--- a/src/lash/worktree-manager.ts
+++ b/src/lash/worktree-manager.ts
@@ -75,18 +75,19 @@ function _parseConflictFiles(output: string): string[] {
  *   'git_error' on other git failures.
  */
 export async function createWorktree(moduleId: string, projectRoot: string = '.'): Promise<WorktreeInfo> {
-  const path = _worktreePath(moduleId, projectRoot);
+  const resolvedProjectRoot = resolve(projectRoot);
+  const path = _worktreePath(moduleId, resolvedProjectRoot);
   const branch = _branchName(moduleId);
 
   // Get current HEAD sha to branch from
-  const headResult = await runGit(['rev-parse', 'HEAD'], projectRoot);
+  const headResult = await runGit(['rev-parse', 'HEAD'], resolvedProjectRoot);
   if (headResult.returncode !== 0) {
     throw new Error(`git_error: could not resolve HEAD: ${headResult.stderr.trim()}`);
   }
   const headSha = headResult.stdout.trim();
 
   // Create the worktree on a new branch
-  const result = await runGit(['worktree', 'add', '-b', branch, path, headSha], projectRoot);
+  const result = await runGit(['worktree', 'add', '-b', branch, path, headSha], resolvedProjectRoot);
   if (result.returncode !== 0) {
     const stderr = result.stderr.trim();
     if (stderr.includes('already exists') || stderr.includes('already checked out')) {
@@ -96,7 +97,7 @@ export async function createWorktree(moduleId: string, projectRoot: string = '.'
   }
 
   // Symlink node_modules from main repo — worktrees lack it (gitignored). (#37)
-  const srcModules = resolve(projectRoot, 'node_modules');
+  const srcModules = resolve(resolvedProjectRoot, 'node_modules');
   const destModules = join(path, 'node_modules');
   if (existsSync(srcModules) && !existsSync(destModules)) {
     symlinkSync(srcModules, destModules, 'dir');
@@ -115,28 +116,29 @@ export async function createWorktree(moduleId: string, projectRoot: string = '.'
  *   'git_error' on unexpected git failures.
  */
 export async function mergeToMain(moduleId: string, projectRoot: string = '.'): Promise<MergeResult> {
+  const resolvedProjectRoot = resolve(projectRoot);
   const branch = _branchName(moduleId);
 
   // Verify worktree exists
-  const listResult = await runGit(['worktree', 'list'], projectRoot);
-  const path = _worktreePath(moduleId, projectRoot);
+  const listResult = await runGit(['worktree', 'list'], resolvedProjectRoot);
+  const path = _worktreePath(moduleId, resolvedProjectRoot);
   if (!listResult.stdout.includes(path)) {
     throw new Error(`no_worktree: no worktree found for ${moduleId}`);
   }
 
   // Switch to main
-  const checkoutResult = await runGit(['checkout', 'main'], projectRoot);
+  const checkoutResult = await runGit(['checkout', 'main'], resolvedProjectRoot);
   if (checkoutResult.returncode !== 0) {
     throw new Error(`git_error: could not checkout main: ${checkoutResult.stderr.trim()}`);
   }
 
   // Attempt merge --no-ff
-  const mergeResult = await runGit(['merge', '--no-ff', branch], projectRoot);
+  const mergeResult = await runGit(['merge', '--no-ff', branch], resolvedProjectRoot);
 
   if (mergeResult.returncode !== 0) {
     // Conflict — abort and report conflict files
     const conflictFiles = _parseConflictFiles(mergeResult.stdout);
-    await runGit(['merge', '--abort'], projectRoot);
+    await runGit(['merge', '--abort'], resolvedProjectRoot);
     return {
       success: false,
       branch_name: branch,
@@ -146,7 +148,7 @@ export async function mergeToMain(moduleId: string, projectRoot: string = '.'): 
   }
 
   // Success — get merge commit sha
-  const commitResult = await runGit(['rev-parse', 'HEAD'], projectRoot);
+  const commitResult = await runGit(['rev-parse', 'HEAD'], resolvedProjectRoot);
   const mergeCommit = commitResult.returncode === 0 ? commitResult.stdout.trim() : null;
 
   return {
@@ -164,17 +166,18 @@ export async function mergeToMain(moduleId: string, projectRoot: string = '.'): 
  *   'git_error' on git failures.
  */
 export async function cleanupWorktree(moduleId: string, projectRoot: string = '.'): Promise<void> {
-  const path = _worktreePath(moduleId, projectRoot);
+  const resolvedProjectRoot = resolve(projectRoot);
+  const path = _worktreePath(moduleId, resolvedProjectRoot);
   const branch = _branchName(moduleId);
 
   // Remove the worktree
-  const removeResult = await runGit(['worktree', 'remove', '--force', path], projectRoot);
+  const removeResult = await runGit(['worktree', 'remove', '--force', path], resolvedProjectRoot);
   if (removeResult.returncode !== 0) {
     throw new Error(`git_error: could not remove worktree: ${removeResult.stderr.trim()}`);
   }
 
   // Delete the branch
-  const branchResult = await runGit(['branch', '-D', branch], projectRoot);
+  const branchResult = await runGit(['branch', '-D', branch], resolvedProjectRoot);
   if (branchResult.returncode !== 0) {
     throw new Error(`git_error: could not delete branch ${branch}: ${branchResult.stderr.trim()}`);
   }
@@ -186,7 +189,7 @@ export async function cleanupWorktree(moduleId: string, projectRoot: string = '.
  * Returns PreserveResult: { preserved_path }
  */
 export function preserveWorktree(moduleId: string, reason: string, projectRoot: string = '.'): PreserveResult {
-  const path = _worktreePath(moduleId, projectRoot);
+  const path = _worktreePath(moduleId, resolve(projectRoot));
   return { preserved_path: path };
 }
 
@@ -204,25 +207,26 @@ export async function createConflictResolutionWorktree(
   targetBranch: string,
   projectRoot: string = '.',
 ): Promise<WorktreeInfo> {
+  const resolvedProjectRoot = resolve(projectRoot);
   const resolveModuleId = `${moduleId}-conflict-resolve`;
-  const path = _worktreePath(resolveModuleId, projectRoot);
+  const path = _worktreePath(resolveModuleId, resolvedProjectRoot);
   const branch = _branchName(resolveModuleId);
 
   // Get sha of source branch HEAD
-  const headResult = await runGit(['rev-parse', sourceBranch], projectRoot);
+  const headResult = await runGit(['rev-parse', sourceBranch], resolvedProjectRoot);
   if (headResult.returncode !== 0) {
     throw new Error(`git_error: could not resolve ${sourceBranch}: ${headResult.stderr.trim()}`);
   }
   const headSha = headResult.stdout.trim();
 
   // Create the conflict resolution worktree
-  const result = await runGit(['worktree', 'add', '-b', branch, path, headSha], projectRoot);
+  const result = await runGit(['worktree', 'add', '-b', branch, path, headSha], resolvedProjectRoot);
   if (result.returncode !== 0) {
     throw new Error(`git_error: ${result.stderr.trim()}`);
   }
 
   // Symlink node_modules from main repo (#37)
-  const srcModules = resolve(projectRoot, 'node_modules');
+  const srcModules = resolve(resolvedProjectRoot, 'node_modules');
   const destModules = join(path, 'node_modules');
   if (existsSync(srcModules) && !existsSync(destModules)) {
     symlinkSync(srcModules, destModules, 'dir');
@@ -241,7 +245,7 @@ export async function checkUnexpectedFiles(
   ownedFiles: string[],
   projectRoot: string = '.',
 ): Promise<UnexpectedFilesResult> {
-  const worktree = _worktreePath(moduleId, projectRoot);
+  const worktree = _worktreePath(moduleId, resolve(projectRoot));
 
   // Get list of modified files in the worktree compared to its base
   const result = await runGit(['diff', '--name-only', 'HEAD'], worktree);

--- a/tests/platform-launcher.test.ts
+++ b/tests/platform-launcher.test.ts
@@ -175,12 +175,27 @@ describe('spawnWorker', () => {
 
     expect(fullCmd[0]).toBe('codex');
     expect(fullCmd).toContain('exec');
-    expect(fullCmd).toContain('-c');
-    expect(fullCmd).toContain('approval_policy=auto-edit');
+    expect(fullCmd).toContain('--full-auto');
     expect(fullCmd).toContain('fix bug Y');
 
     expect(handle.platform).toBe('codex');
     expect(handle.pid).toBe(99);
+  });
+
+  it('TEST-016b: codex spawn passes system prompt file when provided', () => {
+    const mockProc = makeMockProc({ pid: 100 });
+    mockSpawn.mockReturnValue(mockProc);
+
+    spawnWorker('codex', 'implement benchmark contracts', '/tmp/worktree2', '.lash/worker-instructions.md');
+
+    const [bin, args] = mockSpawn.mock.calls[0] as [string, string[], unknown];
+    const fullCmd = [bin, ...args];
+
+    expect(fullCmd[0]).toBe('codex');
+    expect(fullCmd).toContain('exec');
+    expect(fullCmd).toContain('--full-auto');
+    expect(fullCmd).toContain('system_prompt_file=.lash/worker-instructions.md');
+    expect(fullCmd).toContain('implement benchmark contracts');
   });
 
   // TEST-017: OpenCode spawn → correct command

--- a/tests/platform-launcher.test.ts
+++ b/tests/platform-launcher.test.ts
@@ -176,6 +176,8 @@ describe('spawnWorker', () => {
     expect(fullCmd[0]).toBe('codex');
     expect(fullCmd).toContain('exec');
     expect(fullCmd).toContain('--full-auto');
+    expect(fullCmd[1]).toBe('exec');
+    expect(fullCmd[2]).toBe('--full-auto');
     expect(fullCmd).toContain('fix bug Y');
 
     expect(handle.platform).toBe('codex');
@@ -194,6 +196,9 @@ describe('spawnWorker', () => {
     expect(fullCmd[0]).toBe('codex');
     expect(fullCmd).toContain('exec');
     expect(fullCmd).toContain('--full-auto');
+    const promptFlagIndex = fullCmd.indexOf('system_prompt_file=.lash/worker-instructions.md');
+    expect(promptFlagIndex).toBeGreaterThan(0);
+    expect(fullCmd[promptFlagIndex - 1]).toBe('-c');
     expect(fullCmd).toContain('system_prompt_file=.lash/worker-instructions.md');
     expect(fullCmd).toContain('implement benchmark contracts');
   });

--- a/tests/task-packager.test.ts
+++ b/tests/task-packager.test.ts
@@ -336,6 +336,7 @@ describe('TEST-041: codex worker instructions', () => {
       'utf8',
     );
     expect(content).toContain('system_prompt_file');
+    expect(content).toContain('codex exec --full-auto -c system_prompt_file=.lash/worker-instructions.md <task>');
   });
 });
 

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -129,10 +129,10 @@ describe('createWorktree (TEST-031)', () => {
     await createWorktree('MOD-003', 'relative/project');
 
     const [, worktreeArgs] = mockExecFile.mock.calls[1] as [string, string[], unknown];
-    expect(worktreeArgs).toContain(join('relative/project', '.lash', 'worktrees', 'MOD-003'));
+    expect(worktreeArgs).toContain(resolve('relative/project', '.lash', 'worktrees', 'MOD-003'));
     expect(mockSymlinkSync).toHaveBeenCalledWith(
       resolve('relative/project', 'node_modules'),
-      join('relative/project', '.lash', 'worktrees', 'MOD-003', 'node_modules'),
+      resolve('relative/project', '.lash', 'worktrees', 'MOD-003', 'node_modules'),
       'dir',
     );
   });
@@ -338,7 +338,7 @@ describe('createConflictResolutionWorktree (TEST-037)', () => {
 
     expect(mockSymlinkSync).toHaveBeenCalledWith(
       resolve('relative/project', 'node_modules'),
-      join('relative/project', '.lash', 'worktrees', 'MOD-003-conflict-resolve', 'node_modules'),
+      resolve('relative/project', '.lash', 'worktrees', 'MOD-003-conflict-resolve', 'node_modules'),
       'dir',
     );
   });

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -10,10 +10,19 @@ import { join } from 'node:path';
 // vi.hoisted() ensures mockExecFile is declared before vi.mock hoisting.
 // ---------------------------------------------------------------------------
 
-const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
+const { mockExecFile, mockExistsSync, mockSymlinkSync } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockSymlinkSync: vi.fn(),
+}));
 
 vi.mock('node:child_process', () => ({
   execFile: mockExecFile,
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  symlinkSync: mockSymlinkSync,
 }));
 
 // Mock node:util promisify to return an async wrapper around the mocked exec.
@@ -70,6 +79,9 @@ function queueFail(stdout = '', stderr = '', code = 1) {
 
 beforeEach(() => {
   mockExecFile.mockReset();
+  mockExistsSync.mockReset();
+  mockExistsSync.mockReturnValue(false);
+  mockSymlinkSync.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -110,11 +122,19 @@ describe('createWorktree (TEST-031)', () => {
   it('resolves node_modules symlink source from project root', async () => {
     queueOk('abc1234\n');
     queueOk();
+    mockExistsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
 
     await createWorktree('MOD-003', 'relative/project');
 
     const [, worktreeArgs] = mockExecFile.mock.calls[1] as [string, string[], unknown];
     expect(worktreeArgs).toContain(join('relative/project', '.lash', 'worktrees', 'MOD-003'));
+    expect(mockSymlinkSync).toHaveBeenCalledWith(
+      join(process.cwd(), 'relative/project', 'node_modules'),
+      join('relative/project', '.lash', 'worktrees', 'MOD-003', 'node_modules'),
+      'dir',
+    );
   });
 });
 
@@ -305,6 +325,22 @@ describe('createConflictResolutionWorktree (TEST-037)', () => {
     );
 
     expect(result.branch_name).toBe('lash/MOD-007-conflict-resolve');
+  });
+
+  it('links node_modules into the conflict resolution worktree from the project root', async () => {
+    queueOk('abc1234\n');
+    queueOk();
+    mockExistsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+
+    await createConflictResolutionWorktree('MOD-003', 'lash/MOD-003', 'main', 'relative/project');
+
+    expect(mockSymlinkSync).toHaveBeenCalledWith(
+      join(process.cwd(), 'relative/project', 'node_modules'),
+      join('relative/project', '.lash', 'worktrees', 'MOD-003-conflict-resolve', 'node_modules'),
+      'dir',
+    );
   });
 
   it('throws git_error on worktree add failure', async () => {

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -3,7 +3,7 @@
  * Translated from tests/test_worktree_manager.py
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Mock node:child_process at the execFile level so runGit is intercepted.
@@ -131,7 +131,7 @@ describe('createWorktree (TEST-031)', () => {
     const [, worktreeArgs] = mockExecFile.mock.calls[1] as [string, string[], unknown];
     expect(worktreeArgs).toContain(join('relative/project', '.lash', 'worktrees', 'MOD-003'));
     expect(mockSymlinkSync).toHaveBeenCalledWith(
-      join(process.cwd(), 'relative/project', 'node_modules'),
+      resolve('relative/project', 'node_modules'),
       join('relative/project', '.lash', 'worktrees', 'MOD-003', 'node_modules'),
       'dir',
     );
@@ -337,7 +337,7 @@ describe('createConflictResolutionWorktree (TEST-037)', () => {
     await createConflictResolutionWorktree('MOD-003', 'lash/MOD-003', 'main', 'relative/project');
 
     expect(mockSymlinkSync).toHaveBeenCalledWith(
-      join(process.cwd(), 'relative/project', 'node_modules'),
+      resolve('relative/project', 'node_modules'),
       join('relative/project', '.lash', 'worktrees', 'MOD-003-conflict-resolve', 'node_modules'),
       'dir',
     );

--- a/tests/worktree-manager.test.ts
+++ b/tests/worktree-manager.test.ts
@@ -106,6 +106,16 @@ describe('createWorktree (TEST-031)', () => {
 
     await expect(createWorktree('MOD-003', PROJECT_ROOT)).rejects.toThrow('git_error');
   });
+
+  it('resolves node_modules symlink source from project root', async () => {
+    queueOk('abc1234\n');
+    queueOk();
+
+    await createWorktree('MOD-003', 'relative/project');
+
+    const [, worktreeArgs] = mockExecFile.mock.calls[1] as [string, string[], unknown];
+    expect(worktreeArgs).toContain(join('relative/project', '.lash', 'worktrees', 'MOD-003'));
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- update the Codex launcher path to use a working non-interactive execution mode and pass through worker system prompts correctly
- fix worktree node_modules resolution so worker environments inherit dependencies from the project root instead of creating broken self-referential links
- cover the launcher and worktree behavior changes with focused regression tests

## Verification
- pnpm test tests/platform-launcher.test.ts tests/worktree-manager.test.ts
- pnpm lint
- pnpm build