### PR TITLE
fix: support split artifact index entry paths

### DIFF
--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -98,3 +98,16 @@
   - discover split child 仍然采用 `Object.assign` 合并，若未来要对 `requirements` / `core_scenarios` 做更强结构校验，还需单独补 schema 级验证
 - 值得深入研究的问题:
   - 是否在 resolver 层统一接入 schema 校验，而不仅是路径解析与基础结构拼装
+
+## Progress Snapshot: 2026-04-09 21:35
+- 触发方式: 最后一轮 merge blocker 修补
+- 代码统计: 本次继续修改 `spec-resolver` 与回归测试，补齐 split index `modules` 字段强校验
+- 当前版本: V0.0.6 缺陷修复中
+- 本次工作:
+  - 将 split `tests/build` 的 `index.json` 中 `modules` 读取从默认空数组改为强校验，缺失或包含非法项时明确抛出 `INVALID_INDEX_PAYLOAD`
+  - 新增 `tests/spec-resolver.test.ts` 负向用例，覆盖 split tests/build index 缺失 `modules` 与 `modules` 含非法项两类场景
+  - 消除 split index 元数据错误时的静默空聚合风险
+- 当前问题:
+  - `resolveDiscover()` 仍未对 split child 内容做 schema 级结构校验，只保证文件存在且 JSON 可解析
+- 值得深入研究的问题:
+  - 是否应在 resolver 层统一接入 artifact schema 校验，以便将 discover/spec/tests/build 的结构错误统一前置到加载阶段

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -70,3 +70,18 @@
 - 下一步: /build 执行, 或先 review spec 产出
 - Issues: 8 个 open
 - 基线对比: 上次快照 2026-04-04 20:50 | 无代码变更, 新增 brownfield feature 设计制品
+
+## Progress Snapshot: 2026-04-09 19:55
+- 触发方式: 排查并修复 issue #78 及同类 split artifact 入口缺口
+- 代码统计: 本次修改 `lash` resolver、CLI、profile writer 与相关测试，补充 split artifact 回归覆盖
+- 当前版本: V0.0.6 缺陷修复中
+- 本次工作:
+  - 将 `src/lash/spec-resolver.ts` 的 artifact 入口判定统一为“语义入口”而非“物理文件/目录类型”，显式传入 `spec/index.json`、`discover/index.json` 时会归一化到 split artifact 根目录再加载
+  - 新增 `resolveTests()`，使 `lash package --tests` 支持 `tests.json`、`tests/` 与 `tests/index.json` 三种入口
+  - 新增 `resolveBuildReport()`，并让 `src/profile/writer.ts` 复用 `resolveDiscover()` / `resolveSpec()` / `resolveBuildReport()`，补齐 profile writer 对 split discover/spec/build artifact 的支持
+  - 补充回归测试: `tests/spec-resolver.test.ts`、`tests/plan-generator.test.ts`、`tests/cli.test.ts`、`src/profile/__tests__/writer.test.ts`
+  - 同步更新 `docs/zh-CN/USER_GUIDE.md` 中 `lash package` 参数说明，明确 artifact 入口路径支持单文件、目录和显式 `index.json`
+- 当前问题:
+  - `profile writer` 之前一直按单文件入口读取 stage artifact，这次已补齐 split discover/spec/build 支持，但其他非 Lash 路径若未来新增 artifact loader，仍需优先复用统一 resolver，避免再次出现入口语义分叉
+- 值得深入研究的问题:
+  - 是否将 `decisions.json`、未来的 `tests_review` / `build_review` 等 artifact 也统一纳入一层通用 resolver API，进一步消除不同子系统各自读取 JSON 的重复实现

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -85,3 +85,16 @@
   - `profile writer` 之前一直按单文件入口读取 stage artifact，这次已补齐 split discover/spec/build 支持，但其他非 Lash 路径若未来新增 artifact loader，仍需优先复用统一 resolver，避免再次出现入口语义分叉
 - 值得深入研究的问题:
   - 是否将 `decisions.json`、未来的 `tests_review` / `build_review` 等 artifact 也统一纳入一层通用 resolver API，进一步消除不同子系统各自读取 JSON 的重复实现
+
+## Progress Snapshot: 2026-04-09 21:05
+- 触发方式: 子 agent 复审后修补 split child payload 静默降级缺陷
+- 代码统计: 本次修改 `spec-resolver` 与回归测试，新增 malformed split child 负向覆盖
+- 当前版本: V0.0.6 缺陷修复中
+- 本次工作:
+  - 将 `resolveTests()` / `resolveBuildReport()` 对 split child payload 的数组字段读取从“非数组则吞掉”改为“明确抛出 `INVALID_CHILD_PAYLOAD`”
+  - 新增 `tests/spec-resolver.test.ts` 负向用例，覆盖 split tests child 与 split build child 字段类型错误场景
+  - 收紧错误语义，避免上游生成畸形 split child 文件时出现 silent data loss
+- 当前问题:
+  - discover split child 仍然采用 `Object.assign` 合并，若未来要对 `requirements` / `core_scenarios` 做更强结构校验，还需单独补 schema 级验证
+- 值得深入研究的问题:
+  - 是否在 resolver 层统一接入 schema 校验，而不仅是路径解析与基础结构拼装

--- a/docs/zh-CN/USER_GUIDE.md
+++ b/docs/zh-CN/USER_GUIDE.md
@@ -1441,9 +1441,9 @@ lash package MOD-001 .lash/worktrees/MOD-001 claude-code \
 
 | 选项 | 必须 | 说明 |
 |------|------|------|
-| `--spec <path>` | 是 | spec.json 路径 |
-| `--discover <path>` | 是 | discover.json 路径 |
-| `--tests <path>` | 否 | tests.json 路径 |
+| `--spec <path>` | 是 | spec 制品入口路径，可传 `spec.json`、`spec/` 或 `spec/index.json` |
+| `--discover <path>` | 是 | discover 制品入口路径，可传 `discover.json`、`discover/` 或 `discover/index.json` |
+| `--tests <path>` | 否 | tests 制品入口路径，可传 `tests.json`、`tests/` 或 `tests/index.json` |
 | `--completed <m1,m2>` | 否 | 已完成的模块 ID（逗号分隔） |
 
 **输出：**

--- a/src/lash/cli.ts
+++ b/src/lash/cli.ts
@@ -123,9 +123,9 @@ worktreeCmd
 program
   .command('package <module_id> <worktree_path> <platform>')
   .description('Generate .lash/ task package for a worker')
-  .option('--spec <path>', 'Path to spec.json (auto-detected if omitted)')
-  .option('--discover <path>', 'Path to discover.json (auto-detected if omitted)')
-  .option('--tests <path>', 'Path to tests.json')
+  .option('--spec <path>', 'Path to spec artifact (spec.json, spec/, or spec/index.json)')
+  .option('--discover <path>', 'Path to discover artifact (discover.json, discover/, or discover/index.json)')
+  .option('--tests <path>', 'Path to tests artifact (tests.json, tests/, or tests/index.json)')
   .option('--completed <m1,m2>', 'Comma-separated completed module IDs')
   .action(async (
     moduleId: string,
@@ -134,8 +134,7 @@ program
     opts: { spec?: string; discover?: string; tests?: string; completed?: string },
   ) => {
     const { generatePackage } = await import('./task-packager.js');
-    const { readFileSync } = await import('node:fs');
-    const { resolveSpec, resolveDiscover, resolveArtifactPaths } = await import('./spec-resolver.js');
+    const { resolveSpec, resolveDiscover, resolveTests, resolveArtifactPaths } = await import('./spec-resolver.js');
     try {
       if (!opts.spec || !opts.discover) {
         const resolved = resolveArtifactPaths();
@@ -146,7 +145,7 @@ program
       const { discover } = resolveDiscover(opts.discover) as { discover: Record<string, unknown> };
       let tests: Record<string, unknown>;
       if (opts.tests) {
-        tests = JSON.parse(readFileSync(opts.tests, 'utf-8'));
+        tests = resolveTests(opts.tests).tests as Record<string, unknown>;
       } else {
         tests = {
           example_cases: [],

--- a/src/lash/spec-resolver.ts
+++ b/src/lash/spec-resolver.ts
@@ -9,7 +9,7 @@
  */
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { cwd as processCwd } from 'node:process';
 
 // ---------------------------------------------------------------------------
@@ -43,6 +43,36 @@ interface Discover {
   [key: string]: unknown;
 }
 
+interface TestsArtifact {
+  phase?: string;
+  artifact?: string;
+  example_cases?: Array<Record<string, unknown>>;
+  property_cases?: Array<Record<string, unknown>>;
+  coverage_summary?: Record<string, unknown>;
+  coverage_guards?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface BuildReportArtifact {
+  phase?: string;
+  execution_plan?: Record<string, unknown>;
+  tracer_bullet_result?: Record<string, unknown>;
+  test_summary?: Record<string, unknown>;
+  acceptance_result?: Record<string, unknown>;
+  contract_amendments?: Array<Record<string, unknown>>;
+  auto_decisions?: Array<Record<string, unknown>>;
+  unresolved_issues?: unknown[];
+  module_results?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+type ArtifactFormat = 'single_file' | 'split_directory';
+
+interface ResolvedArtifactInput {
+  format: ArtifactFormat;
+  normalizedPath: string;
+}
+
 // ---------------------------------------------------------------------------
 // detectFormat
 // ---------------------------------------------------------------------------
@@ -52,6 +82,10 @@ interface Discover {
  * @throws Error with PATH_NOT_FOUND or INDEX_MISSING
  */
 export function detectFormat(inputPath: string): 'single_file' | 'split_directory' {
+  return resolveArtifactInput(inputPath).format;
+}
+
+function resolveArtifactInput(inputPath: string): ResolvedArtifactInput {
   const abs = resolve(inputPath);
 
   if (!existsSync(abs)) {
@@ -61,7 +95,11 @@ export function detectFormat(inputPath: string): 'single_file' | 'split_director
   const stat = statSync(abs);
 
   if (stat.isFile()) {
-    return 'single_file';
+    if (basename(abs) === 'index.json') {
+      const dirPath = dirname(abs);
+      return { format: 'split_directory', normalizedPath: dirPath };
+    }
+    return { format: 'single_file', normalizedPath: abs };
   }
 
   if (stat.isDirectory()) {
@@ -69,7 +107,7 @@ export function detectFormat(inputPath: string): 'single_file' | 'split_director
     if (!existsSync(indexPath)) {
       throw new Error(`[INDEX_MISSING] Directory does not contain index.json (path: ${abs})`);
     }
-    return 'split_directory';
+    return { format: 'split_directory', normalizedPath: abs };
   }
 
   throw new Error(`[PATH_NOT_FOUND] Path is neither a file nor directory (path: ${abs})`);
@@ -85,13 +123,13 @@ export function detectFormat(inputPath: string): 'single_file' | 'split_director
  * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, MODULE_FILE_MISSING, INVALID_JSON, INVALID_DEPENDENCY_REF
  */
 export function resolveSpec(specPath: string): { spec: Spec; specHash: string } {
-  const format = detectFormat(specPath);
+  const { format, normalizedPath } = resolveArtifactInput(specPath);
 
   if (format === 'single_file') {
-    return loadSingleSpec(specPath);
+    return loadSingleSpec(normalizedPath);
   }
 
-  return loadSplitSpec(specPath);
+  return loadSplitSpec(normalizedPath);
 }
 
 function loadSingleSpec(filePath: string): { spec: Spec; specHash: string } {
@@ -169,16 +207,15 @@ function loadSplitSpec(dirPath: string): { spec: Spec; specHash: string } {
  * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON
  */
 export function resolveDiscover(discoverPath: string): { discover: Discover } {
-  const format = detectFormat(discoverPath);
+  const { format, normalizedPath } = resolveArtifactInput(discoverPath);
 
   if (format === 'single_file') {
-    const abs = resolve(discoverPath);
-    const text = readFileSync(abs, 'utf8');
-    const discover: Discover = parseJson(text, abs);
+    const text = readFileSync(normalizedPath, 'utf8');
+    const discover: Discover = parseJson(text, normalizedPath);
     return { discover };
   }
 
-  return loadSplitDiscover(discoverPath);
+  return loadSplitDiscover(normalizedPath);
 }
 
 function loadSplitDiscover(dirPath: string): { discover: Discover } {
@@ -206,6 +243,102 @@ function loadSplitDiscover(dirPath: string): { discover: Discover } {
 }
 
 // ---------------------------------------------------------------------------
+// resolveTests
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a tests artifact from a single file or split directory.
+ * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON
+ */
+export function resolveTests(testsPath: string): { tests: TestsArtifact } {
+  const { format, normalizedPath } = resolveArtifactInput(testsPath);
+
+  if (format === 'single_file') {
+    const text = readFileSync(normalizedPath, 'utf8');
+    const tests: TestsArtifact = parseJson(text, normalizedPath);
+    return { tests };
+  }
+
+  return loadSplitTests(normalizedPath);
+}
+
+function loadSplitTests(dirPath: string): { tests: TestsArtifact } {
+  const abs = resolve(dirPath);
+  const indexPath = join(abs, 'index.json');
+  const indexText = readFileSync(indexPath, 'utf8');
+  const index = parseJson(indexText, indexPath) as Record<string, unknown>;
+
+  const moduleFiles = (index.modules ?? []) as string[];
+  const merged: TestsArtifact = {
+    ...index,
+    example_cases: [],
+    property_cases: [],
+  };
+
+  delete merged.modules;
+
+  for (const filename of moduleFiles) {
+    const childPath = join(abs, filename);
+    if (!existsSync(childPath)) {
+      throw new Error(`[CHILD_FILE_MISSING] Referenced child file not found (path: ${childPath})`);
+    }
+    const childText = readFileSync(childPath, 'utf8');
+    const childData = parseJson(childText, childPath) as Record<string, unknown>;
+    merged.example_cases!.push(...extractObjectArray(childData.example_cases));
+    merged.property_cases!.push(...extractObjectArray(childData.property_cases));
+  }
+
+  return { tests: merged };
+}
+
+// ---------------------------------------------------------------------------
+// resolveBuildReport
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a build report artifact from a single file or split directory.
+ * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON
+ */
+export function resolveBuildReport(buildPath: string): { buildReport: BuildReportArtifact } {
+  const { format, normalizedPath } = resolveArtifactInput(buildPath);
+
+  if (format === 'single_file') {
+    const text = readFileSync(normalizedPath, 'utf8');
+    const buildReport: BuildReportArtifact = parseJson(text, normalizedPath);
+    return { buildReport };
+  }
+
+  return loadSplitBuildReport(normalizedPath);
+}
+
+function loadSplitBuildReport(dirPath: string): { buildReport: BuildReportArtifact } {
+  const abs = resolve(dirPath);
+  const indexPath = join(abs, 'index.json');
+  const indexText = readFileSync(indexPath, 'utf8');
+  const index = parseJson(indexText, indexPath) as Record<string, unknown>;
+
+  const moduleFiles = (index.modules ?? []) as string[];
+  const merged: BuildReportArtifact = {
+    ...index,
+    module_results: [],
+  };
+
+  delete merged.modules;
+
+  for (const filename of moduleFiles) {
+    const childPath = join(abs, filename);
+    if (!existsSync(childPath)) {
+      throw new Error(`[CHILD_FILE_MISSING] Referenced child file not found (path: ${childPath})`);
+    }
+    const childText = readFileSync(childPath, 'utf8');
+    const childData = parseJson(childText, childPath) as Record<string, unknown>;
+    merged.module_results!.push(...extractObjectArray(childData.module_results));
+  }
+
+  return { buildReport: merged };
+}
+
+// ---------------------------------------------------------------------------
 // Shared helper
 // ---------------------------------------------------------------------------
 
@@ -215,6 +348,16 @@ function parseJson<T>(text: string, sourcePath: string): T {
   } catch {
     throw new Error(`[INVALID_JSON] Failed to parse JSON (path: ${sourcePath})`);
   }
+}
+
+function extractObjectArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (item): item is Record<string, unknown> => typeof item === 'object' && item !== null,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lash/spec-resolver.ts
+++ b/src/lash/spec-resolver.ts
@@ -204,7 +204,7 @@ function loadSplitSpec(dirPath: string): { spec: Spec; specHash: string } {
 
 /**
  * Load a discover artifact from a single file or split directory.
- * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON
+ * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON, INVALID_INDEX_PAYLOAD, INVALID_CHILD_PAYLOAD
  */
 export function resolveDiscover(discoverPath: string): { discover: Discover } {
   const { format, normalizedPath } = resolveArtifactInput(discoverPath);
@@ -268,7 +268,7 @@ function loadSplitTests(dirPath: string): { tests: TestsArtifact } {
   const indexText = readFileSync(indexPath, 'utf8');
   const index = parseJson(indexText, indexPath) as Record<string, unknown>;
 
-  const moduleFiles = (index.modules ?? []) as string[];
+  const moduleFiles = requireStringArray(index.modules, indexPath, 'modules');
   const merged: TestsArtifact = {
     ...index,
     example_cases: [],
@@ -301,7 +301,7 @@ function loadSplitTests(dirPath: string): { tests: TestsArtifact } {
 
 /**
  * Load a build report artifact from a single file or split directory.
- * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON
+ * @throws Error with PATH_NOT_FOUND, INDEX_MISSING, CHILD_FILE_MISSING, INVALID_JSON, INVALID_INDEX_PAYLOAD, INVALID_CHILD_PAYLOAD
  */
 export function resolveBuildReport(buildPath: string): { buildReport: BuildReportArtifact } {
   const { format, normalizedPath } = resolveArtifactInput(buildPath);
@@ -321,7 +321,7 @@ function loadSplitBuildReport(dirPath: string): { buildReport: BuildReportArtifa
   const indexText = readFileSync(indexPath, 'utf8');
   const index = parseJson(indexText, indexPath) as Record<string, unknown>;
 
-  const moduleFiles = (index.modules ?? []) as string[];
+  const moduleFiles = requireStringArray(index.modules, indexPath, 'modules');
   const merged: BuildReportArtifact = {
     ...index,
     module_results: [],
@@ -378,6 +378,30 @@ function requireObjectArray(
   }
 
   return value as Array<Record<string, unknown>>;
+}
+
+function requireStringArray(
+  value: unknown,
+  sourcePath: string,
+  fieldName: string,
+): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `[INVALID_INDEX_PAYLOAD] Expected '${fieldName}' to be an array in split index file (path: ${sourcePath})`
+    );
+  }
+
+  const invalidItemIndex = value.findIndex(
+    (item) => typeof item !== 'string' || item.length === 0,
+  );
+
+  if (invalidItemIndex !== -1) {
+    throw new Error(
+      `[INVALID_INDEX_PAYLOAD] Expected '${fieldName}' entries to be non-empty strings in split index file (path: ${sourcePath}, index: ${invalidItemIndex})`
+    );
+  }
+
+  return value;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lash/spec-resolver.ts
+++ b/src/lash/spec-resolver.ts
@@ -284,8 +284,12 @@ function loadSplitTests(dirPath: string): { tests: TestsArtifact } {
     }
     const childText = readFileSync(childPath, 'utf8');
     const childData = parseJson(childText, childPath) as Record<string, unknown>;
-    merged.example_cases!.push(...extractObjectArray(childData.example_cases));
-    merged.property_cases!.push(...extractObjectArray(childData.property_cases));
+    merged.example_cases!.push(
+      ...requireObjectArray(childData.example_cases, childPath, 'example_cases')
+    );
+    merged.property_cases!.push(
+      ...requireObjectArray(childData.property_cases, childPath, 'property_cases')
+    );
   }
 
   return { tests: merged };
@@ -332,7 +336,9 @@ function loadSplitBuildReport(dirPath: string): { buildReport: BuildReportArtifa
     }
     const childText = readFileSync(childPath, 'utf8');
     const childData = parseJson(childText, childPath) as Record<string, unknown>;
-    merged.module_results!.push(...extractObjectArray(childData.module_results));
+    merged.module_results!.push(
+      ...requireObjectArray(childData.module_results, childPath, 'module_results')
+    );
   }
 
   return { buildReport: merged };
@@ -350,14 +356,28 @@ function parseJson<T>(text: string, sourcePath: string): T {
   }
 }
 
-function extractObjectArray(value: unknown): Array<Record<string, unknown>> {
+function requireObjectArray(
+  value: unknown,
+  sourcePath: string,
+  fieldName: string,
+): Array<Record<string, unknown>> {
   if (!Array.isArray(value)) {
-    return [];
+    throw new Error(
+      `[INVALID_CHILD_PAYLOAD] Expected '${fieldName}' to be an array in split child file (path: ${sourcePath})`
+    );
   }
 
-  return value.filter(
-    (item): item is Record<string, unknown> => typeof item === 'object' && item !== null,
+  const invalidItemIndex = value.findIndex(
+    (item) => typeof item !== 'object' || item === null,
   );
+
+  if (invalidItemIndex !== -1) {
+    throw new Error(
+      `[INVALID_CHILD_PAYLOAD] Expected '${fieldName}' entries to be objects in split child file (path: ${sourcePath}, index: ${invalidItemIndex})`
+    );
+  }
+
+  return value as Array<Record<string, unknown>>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/profile/__tests__/writer.test.ts
+++ b/src/profile/__tests__/writer.test.ts
@@ -85,6 +85,79 @@ function makeDecisions(overrides: Record<string, unknown> = {}): Record<string, 
   };
 }
 
+function makeSplitDiscoverFiles(baseDir: string, overrides: Record<string, unknown> = {}): void {
+  const discover = makeDiscover(overrides);
+  const discoverDir = path.join(baseDir, 'discover');
+  fs.mkdirSync(discoverDir, { recursive: true });
+  fs.writeFileSync(path.join(discoverDir, 'index.json'), JSON.stringify({
+    phase: 'discover',
+    version: '4.0',
+    status: 'approved',
+    mode: 'full',
+    constraints: discover.constraints,
+    selected_direction: { description: 'test direction' },
+    design_philosophy: discover.design_philosophy,
+    domain_model: discover.domain_model,
+    child_files: {
+      requirements: 'requirements.json',
+      scenarios: 'scenarios.json',
+    },
+    ui_taste: discover.ui_taste,
+  }), 'utf-8');
+  fs.writeFileSync(path.join(discoverDir, 'requirements.json'), JSON.stringify({
+    requirements: discover.requirements ?? [],
+  }), 'utf-8');
+  fs.writeFileSync(path.join(discoverDir, 'scenarios.json'), JSON.stringify({
+    core_scenarios: discover.core_scenarios ?? [],
+  }), 'utf-8');
+}
+
+function makeSplitSpecFiles(baseDir: string, overrides: Record<string, unknown> = {}): void {
+  const spec = makeSpec(overrides);
+  const specDir = path.join(baseDir, 'spec');
+  fs.mkdirSync(specDir, { recursive: true });
+  const modules = (spec.modules as Record<string, unknown>[]) ?? [];
+  const moduleRefs = modules.map((_, idx) => `mod-${String(idx + 1).padStart(3, '0')}.json`);
+  const moduleIds = new Set(modules.map((mod) => String(mod.id ?? '')));
+  const dependencyGraph = (spec.dependency_graph as { edges?: Array<Record<string, unknown>> }) ?? {};
+  const edges = (dependencyGraph.edges ?? []).filter((edge) => {
+    const from = String(edge.from ?? '');
+    const to = String(edge.to ?? '');
+    return moduleIds.has(from) && moduleIds.has(to);
+  });
+  fs.writeFileSync(path.join(specDir, 'index.json'), JSON.stringify({
+    phase: 'spec',
+    version: '4.0',
+    status: 'approved',
+    module_refs: moduleRefs,
+    dependency_graph: { edges },
+  }), 'utf-8');
+  modules.forEach((mod, idx) => {
+    fs.writeFileSync(path.join(specDir, `mod-${String(idx + 1).padStart(3, '0')}.json`), JSON.stringify(mod), 'utf-8');
+  });
+}
+
+function makeSplitBuildFiles(baseDir: string, overrides: Record<string, unknown> = {}): void {
+  const build = makeBuildReport(overrides);
+  const buildDir = path.join(baseDir, 'build_report');
+  fs.mkdirSync(buildDir, { recursive: true });
+  fs.writeFileSync(path.join(buildDir, 'index.json'), JSON.stringify({
+    phase: 'build',
+    version: '4.0',
+    execution_plan: { module_order: ['MOD-001'], tracer_bullet_path: 'SCENARIO-001', rationale: 'test' },
+    tracer_bullet_result: { status: 'passed' },
+    test_summary: build.test_summary,
+    acceptance_result: { scenarios_verified: ['SCENARIO-001'], status: 'all_passed', source: 'critic_agent' },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+    modules: ['mod-001.json'],
+  }), 'utf-8');
+  fs.writeFileSync(path.join(buildDir, 'mod-001.json'), JSON.stringify({
+    module_results: [{ module_ref: 'MOD-001', status: 'completed', retry_history: [], auto_decisions: [] }],
+  }), 'utf-8');
+}
+
 afterEach(() => {
   if (tmpDir && fs.existsSync(tmpDir)) {
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -393,6 +466,32 @@ describe('writeProfileFromArtifacts', () => {
     // At minimum L0 and L3 from discover.json
     expect(result.layersWritten).toContain('l0');
     expect(result.layersWritten).toContain('l3');
+  });
+
+  it('supports split discover/spec/build artifacts in greenfield mode', async () => {
+    const root = setup({
+      '.nopilot/config.json': JSON.stringify({ l2_enabled: false }),
+    });
+    const specsDir = path.join(root, 'specs');
+    fs.mkdirSync(specsDir, { recursive: true });
+    makeSplitDiscoverFiles(specsDir, {
+      requirements: [{ id: 'REQ-001', acceptance_criteria: [] }],
+      core_scenarios: [{ id: 'SCENARIO-001', description: 'test', requirement_refs: ['REQ-001'], priority: 'highest' }],
+    });
+    makeSplitSpecFiles(specsDir);
+    makeSplitBuildFiles(specsDir, {
+      test_summary: { total: 7, passed: 7, failed: 0, framework: 'vitest' },
+    });
+
+    const result = await writeProfileFromArtifacts(root, specsDir, 'greenfield');
+
+    expect(result.layersWritten).toContain('l0');
+    expect(result.layersWritten).toContain('l1');
+    expect(result.layersWritten).toContain('l3');
+
+    const l3 = readLayer(root, 'l3');
+    const data = l3.data as Record<string, unknown>;
+    expect((data.test_coverage as { total_tests: number }).total_tests).toBe(7);
   });
 
   it('TEST-069: throws ARTIFACT_NOT_FOUND when discover.json missing', async () => {

--- a/src/profile/__tests__/writer.test.ts
+++ b/src/profile/__tests__/writer.test.ts
@@ -139,7 +139,7 @@ function makeSplitSpecFiles(baseDir: string, overrides: Record<string, unknown> 
 
 function makeSplitBuildFiles(baseDir: string, overrides: Record<string, unknown> = {}): void {
   const build = makeBuildReport(overrides);
-  const buildDir = path.join(baseDir, 'build_report');
+  const buildDir = path.join(baseDir, 'build');
   fs.mkdirSync(buildDir, { recursive: true });
   fs.writeFileSync(path.join(buildDir, 'index.json'), JSON.stringify({
     phase: 'build',
@@ -492,6 +492,7 @@ describe('writeProfileFromArtifacts', () => {
     const l3 = readLayer(root, 'l3');
     const data = l3.data as Record<string, unknown>;
     expect((data.test_coverage as { total_tests: number }).total_tests).toBe(7);
+    expect((data.test_coverage as { framework: string }).framework).toBe('vitest');
   });
 
   it('TEST-069: throws ARTIFACT_NOT_FOUND when discover.json missing', async () => {

--- a/src/profile/writer.ts
+++ b/src/profile/writer.ts
@@ -41,15 +41,20 @@ function loadArtifact(filePath: string): Record<string, unknown> | null {
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
-function resolveArtifactEntry(artifactsDir: string, baseName: string): string | null {
-  const singleFile = path.join(artifactsDir, `${baseName}.json`);
+function resolveArtifactEntry(
+  artifactsDir: string,
+  options: { singleFile: string; splitDirs?: string[] },
+): string | null {
+  const singleFile = path.join(artifactsDir, options.singleFile);
   if (fs.existsSync(singleFile)) {
     return singleFile;
   }
 
-  const splitDir = path.join(artifactsDir, baseName);
-  if (fs.existsSync(splitDir)) {
-    return splitDir;
+  for (const splitDirName of options.splitDirs ?? []) {
+    const splitDir = path.join(artifactsDir, splitDirName);
+    if (fs.existsSync(splitDir)) {
+      return splitDir;
+    }
   }
 
   return null;
@@ -65,7 +70,10 @@ export async function writeProfileFromArtifacts(
   mode: 'greenfield' | 'feature'
 ): Promise<WriteProfileResult> {
   // 1. Load artifacts
-  const discoverPath = resolveArtifactEntry(artifactsDir, 'discover');
+  const discoverPath = resolveArtifactEntry(artifactsDir, {
+    singleFile: 'discover.json',
+    splitDirs: ['discover'],
+  });
 
   if (discoverPath === null) {
     throw new Error('ARTIFACT_NOT_FOUND: discover artifact not found in ' + artifactsDir);
@@ -80,7 +88,10 @@ export async function writeProfileFromArtifacts(
 
   let specArtifact: Record<string, unknown> | null = null;
   try {
-    const specPath = resolveArtifactEntry(artifactsDir, 'spec');
+    const specPath = resolveArtifactEntry(artifactsDir, {
+      singleFile: 'spec.json',
+      splitDirs: ['spec'],
+    });
     specArtifact = specPath ? resolveSpec(specPath).spec as Record<string, unknown> : null;
   } catch (e) {
     throw new Error('EXTRACTION_FAILED: failed to parse spec artifact: ' + String(e));
@@ -88,7 +99,10 @@ export async function writeProfileFromArtifacts(
 
   let buildReport: Record<string, unknown> | null = null;
   try {
-    const buildPath = resolveArtifactEntry(artifactsDir, 'build_report');
+    const buildPath = resolveArtifactEntry(artifactsDir, {
+      singleFile: 'build_report.json',
+      splitDirs: ['build'],
+    });
     if (buildPath) {
       buildReport = resolveBuildReport(buildPath).buildReport as Record<string, unknown>;
     }

--- a/src/profile/writer.ts
+++ b/src/profile/writer.ts
@@ -4,6 +4,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { resolveBuildReport, resolveDiscover, resolveSpec } from '../lash/spec-resolver.js';
 import { readConfig } from './config.js';
 import { readLayer, writeLayer, profileExists } from './storage.js';
 import { extractL0, extractL1, extractL2, extractL3, mergeDomainModel } from './extractors.js';
@@ -40,6 +41,20 @@ function loadArtifact(filePath: string): Record<string, unknown> | null {
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
+function resolveArtifactEntry(artifactsDir: string, baseName: string): string | null {
+  const singleFile = path.join(artifactsDir, `${baseName}.json`);
+  if (fs.existsSync(singleFile)) {
+    return singleFile;
+  }
+
+  const splitDir = path.join(artifactsDir, baseName);
+  if (fs.existsSync(splitDir)) {
+    return splitDir;
+  }
+
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // writeProfileFromArtifacts
 // ---------------------------------------------------------------------------
@@ -50,32 +65,35 @@ export async function writeProfileFromArtifacts(
   mode: 'greenfield' | 'feature'
 ): Promise<WriteProfileResult> {
   // 1. Load artifacts
-  const discoverPath = path.join(artifactsDir, 'discover.json');
+  const discoverPath = resolveArtifactEntry(artifactsDir, 'discover');
 
-  if (!fs.existsSync(discoverPath)) {
-    throw new Error('ARTIFACT_NOT_FOUND: discover.json not found in ' + artifactsDir);
+  if (discoverPath === null) {
+    throw new Error('ARTIFACT_NOT_FOUND: discover artifact not found in ' + artifactsDir);
   }
 
   let discoverArtifact: Record<string, unknown>;
   try {
-    const raw = fs.readFileSync(discoverPath, 'utf-8');
-    discoverArtifact = JSON.parse(raw) as Record<string, unknown>;
+    discoverArtifact = resolveDiscover(discoverPath).discover as Record<string, unknown>;
   } catch (e) {
-    throw new Error('EXTRACTION_FAILED: failed to parse discover.json: ' + String(e));
+    throw new Error('EXTRACTION_FAILED: failed to parse discover artifact: ' + String(e));
   }
 
   let specArtifact: Record<string, unknown> | null = null;
   try {
-    specArtifact = loadArtifact(path.join(artifactsDir, 'spec.json'));
+    const specPath = resolveArtifactEntry(artifactsDir, 'spec');
+    specArtifact = specPath ? resolveSpec(specPath).spec as Record<string, unknown> : null;
   } catch (e) {
-    throw new Error('EXTRACTION_FAILED: failed to parse spec.json: ' + String(e));
+    throw new Error('EXTRACTION_FAILED: failed to parse spec artifact: ' + String(e));
   }
 
   let buildReport: Record<string, unknown> | null = null;
   try {
-    buildReport = loadArtifact(path.join(artifactsDir, 'build_report.json'));
+    const buildPath = resolveArtifactEntry(artifactsDir, 'build_report');
+    if (buildPath) {
+      buildReport = resolveBuildReport(buildPath).buildReport as Record<string, unknown>;
+    }
   } catch (e) {
-    throw new Error('EXTRACTION_FAILED: failed to parse build_report.json: ' + String(e));
+    throw new Error('EXTRACTION_FAILED: failed to parse build report artifact: ' + String(e));
   }
 
   let decisionsArtifact: Record<string, unknown> | null = null;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -87,6 +87,49 @@ function makeMinimalDiscover(tmpDir: string): string {
   return path;
 }
 
+function makeSplitTests(tmpDir: string): string {
+  const testsDir = join(tmpDir, 'tests');
+  mkdirSync(testsDir, { recursive: true });
+
+  writeJson(join(testsDir, 'index.json'), {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: [],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+    modules: ['mod-a.json'],
+  });
+
+  writeJson(join(testsDir, 'mod-a.json'), {
+    example_cases: [
+      {
+        id: 'TEST-001',
+        suite_type: 'unit',
+        module_ref: 'MOD-A',
+        requirement_refs: ['REQ-001'],
+        description: 'Generate execution plan from valid spec.json',
+        category: 'normal',
+        ears_ref: 'REQ-001-AC-1',
+        derivation: 'direct_from_ears',
+        input: 'spec.json with 1 module',
+        expected_output: 'ExecutionPlan JSON',
+        setup: 'Create temp spec.json',
+      },
+    ],
+    property_cases: [],
+  });
+
+  return join(testsDir, 'index.json');
+}
+
 function makeTestResultFile(tmpDir: string, stderr = 'AssertionError: expected 1 got 2'): string {
   const testResult = {
     passed: false,
@@ -146,6 +189,62 @@ describe('lash plan', () => {
     const result = runLash('plan', specPath, discoverPath);
     const data = JSON.parse(result.stdout);
     expect(data.batches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('accepts explicit split index.json paths', () => {
+    const tmpDir = makeTmpDir();
+    const specDir = join(tmpDir, 'spec');
+    mkdirSync(specDir, { recursive: true });
+    writeJson(join(specDir, 'index.json'), {
+      phase: 'spec',
+      version: '4.0',
+      status: 'approved',
+      module_refs: ['mod-a.json'],
+      dependency_graph: { edges: [] },
+    });
+    writeJson(join(specDir, 'mod-a.json'), {
+      id: 'MOD-A',
+      source_root: 'src/',
+      owned_files: ['a.ts'],
+      depends_on: [],
+      requirement_refs: ['REQ-001'],
+    });
+
+    const discoverDir = join(tmpDir, 'discover');
+    mkdirSync(discoverDir, { recursive: true });
+    writeJson(join(discoverDir, 'index.json'), {
+      phase: 'discover',
+      version: '4.0',
+      status: 'approved',
+      mode: 'full',
+      constraints: {},
+      selected_direction: { description: 'Default' },
+      design_philosophy: [],
+      child_files: {
+        requirements: 'requirements.json',
+        scenarios: 'scenarios.json',
+      },
+    });
+    writeJson(join(discoverDir, 'requirements.json'), {
+      requirements: [{ id: 'REQ-001' }],
+    });
+    writeJson(join(discoverDir, 'scenarios.json'), {
+      core_scenarios: [
+        {
+          id: 'SCENARIO-001',
+          description: 'Default',
+          requirement_refs: ['REQ-001'],
+          priority: 'highest',
+        },
+      ],
+    });
+
+    const result = runLash('plan', join(specDir, 'index.json'), join(discoverDir, 'index.json'));
+    expect(result.returncode).toBe(0);
+
+    const data = JSON.parse(result.stdout);
+    expect(data.batches).toHaveLength(1);
+    expect(data.tracer.scenario_id).toBe('SCENARIO-001');
   });
 });
 
@@ -277,7 +376,41 @@ describe('lash classify', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. lash worktree --help
+// 7. lash package — split tests artifact
+// ---------------------------------------------------------------------------
+
+describe('lash package', () => {
+  it('accepts split tests artifact via explicit index.json path', () => {
+    const tmpDir = makeTmpDir();
+    const worktreeDir = join(tmpDir, 'worktree');
+    mkdirSync(worktreeDir, { recursive: true });
+
+    const specPath = makeMinimalSpec(tmpDir);
+    const discoverPath = makeMinimalDiscover(tmpDir);
+    const testsPath = makeSplitTests(tmpDir);
+
+    const result = runLash(
+      'package',
+      'MOD-A',
+      worktreeDir,
+      'opencode',
+      '--spec', specPath,
+      '--discover', discoverPath,
+      '--tests', testsPath,
+    );
+    expect(result.returncode).toBe(0);
+
+    const data = JSON.parse(result.stdout);
+    expect(Array.isArray(data.files_written)).toBe(true);
+
+    const packagedTests = JSON.parse(readFileSync(join(worktreeDir, '.lash', 'tests.json'), 'utf-8'));
+    expect(packagedTests.example_cases).toHaveLength(1);
+    expect(packagedTests.example_cases[0].module_ref).toBe('MOD-A');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. lash worktree --help
 // ---------------------------------------------------------------------------
 
 describe('lash worktree --help', () => {
@@ -296,7 +429,7 @@ describe('lash worktree --help', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. lash state --help
+// 9. lash state --help
 // ---------------------------------------------------------------------------
 
 describe('lash state --help', () => {

--- a/tests/plan-generator.test.ts
+++ b/tests/plan-generator.test.ts
@@ -3,7 +3,7 @@
  * Translated from tests/test_plan_generator.py
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
@@ -60,6 +60,60 @@ function makeSpec(modules: ModuleEntry[], dependencyGraph?: unknown): unknown {
     modules,
     dependency_graph: graph,
   };
+}
+
+function writeSplitSpec(rootDir: string, modules: ModuleEntry[]): string {
+  const dir = join(rootDir, 'spec');
+  mkdirSync(dir, { recursive: true });
+  const dependencyGraph = { edges: modules.flatMap((mod) => mod.depends_on.map((dep) => ({ from: mod.id, to: dep }))) };
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'spec',
+    version: '3.0',
+    status: 'approved',
+    module_refs: modules.map((mod, idx) => `mod-${String(idx + 1).padStart(3, '0')}.json`),
+    dependency_graph: dependencyGraph,
+  });
+
+  modules.forEach((mod, idx) => {
+    writeJson(join(dir, `mod-${String(idx + 1).padStart(3, '0')}.json`), {
+      id: mod.id,
+      source_root: mod.source_root,
+      owned_files: mod.owned_files,
+      depends_on: mod.depends_on,
+      requirement_refs: mod.requirement_refs,
+    });
+  });
+
+  return dir;
+}
+
+function writeSplitDiscover(rootDir: string, scenarios?: ScenarioEntry[]): string {
+  const dir = join(rootDir, 'discover');
+  mkdirSync(dir, { recursive: true });
+  const discover = makeDiscover(scenarios) as Record<string, unknown>;
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'discover',
+    version: discover.version,
+    status: discover.status,
+    mode: 'full',
+    constraints: {},
+    selected_direction: { description: 'test' },
+    design_philosophy: [],
+    child_files: {
+      requirements: 'requirements.json',
+      scenarios: 'scenarios.json',
+    },
+  });
+  writeJson(join(dir, 'requirements.json'), {
+    requirements: discover.requirements,
+  });
+  writeJson(join(dir, 'scenarios.json'), {
+    core_scenarios: discover.core_scenarios,
+  });
+
+  return dir;
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +375,20 @@ describe('plan-generator', () => {
     expect(tracer.scenario_id).toBe('SCENARIO-001');
     const tracerIds = [...tracer.module_ids].sort();
     expect(tracerIds).toEqual(['MOD-A', 'MOD-B', 'MOD-C']);
+  });
+
+  it('TEST-015: explicit split index paths produce same plan as directory paths', () => {
+    const modules: ModuleEntry[] = [
+      { id: 'MOD-A', source_root: 'src/', owned_files: ['a.py'], depends_on: [], requirement_refs: ['REQ-001'] },
+      { id: 'MOD-B', source_root: 'src/', owned_files: ['b.py'], depends_on: ['MOD-A'], requirement_refs: ['REQ-001'] },
+    ];
+    const specDir = writeSplitSpec(tmp, modules);
+    const discoverDir = writeSplitDiscover(tmp);
+
+    const planByDir = generatePlan(specDir, discoverDir);
+    const planByIndex = generatePlan(join(specDir, 'index.json'), join(discoverDir, 'index.json'));
+
+    expect(planByIndex).toEqual(planByDir);
   });
 
   // Additional: verify batch_id format BATCH-NNN

--- a/tests/spec-resolver.test.ts
+++ b/tests/spec-resolver.test.ts
@@ -179,6 +179,35 @@ function makeSplitTests(tmpDir: string, opts?: { missingChild?: boolean }): stri
   return dir;
 }
 
+function makeSplitTestsWithMalformedChild(tmpDir: string): string {
+  const dir = join(tmpDir, 'tests');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: ['INV-001'],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+    modules: ['mod-001-alpha.json'],
+  });
+
+  writeJson(join(dir, 'mod-001-alpha.json'), {
+    example_cases: { id: 'TEST-001', module_ref: 'MOD-001' },
+    property_cases: [{ id: 'PROP-001', module_ref: 'MOD-001' }],
+  });
+
+  return dir;
+}
+
 function makeSingleBuildReport(tmpDir: string): string {
   const p = join(tmpDir, 'build_report.json');
   writeJson(p, {
@@ -251,6 +280,44 @@ function makeSplitBuildReport(tmpDir: string, opts?: { missingChild?: boolean })
       module_results: [{ module_ref: 'MOD-002', status: 'degraded', retry_history: [], auto_decisions: [] }],
     });
   }
+
+  return dir;
+}
+
+function makeSplitBuildReportWithMalformedChild(tmpDir: string): string {
+  const dir = join(tmpDir, 'build');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    version: '4.0',
+    execution_plan: {
+      module_order: ['MOD-001'],
+      tracer_bullet_path: 'SCENARIO-001',
+      rationale: 'test',
+    },
+    tracer_bullet_result: { status: 'passed' },
+    test_summary: {
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      framework: 'vitest',
+    },
+    acceptance_result: {
+      scenarios_verified: ['SCENARIO-001'],
+      status: 'all_passed',
+      source: 'critic_agent',
+    },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+    modules: ['mod-001-alpha.json'],
+  });
+
+  writeJson(join(dir, 'mod-001-alpha.json'), {
+    module_results: { module_ref: 'MOD-001', status: 'completed' },
+  });
 
   return dir;
 }
@@ -475,6 +542,12 @@ describe('resolveTests', () => {
     const testsDir = makeSplitTests(tmp, { missingChild: true });
     expect(() => resolveTests(testsDir)).toThrow('CHILD_FILE_MISSING');
   });
+
+  it('TEST-026-029: throws INVALID_CHILD_PAYLOAD when split tests child fields are malformed', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTestsWithMalformedChild(tmp);
+    expect(() => resolveTests(testsDir)).toThrow('INVALID_CHILD_PAYLOAD');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -514,6 +587,12 @@ describe('resolveBuildReport', () => {
     const tmp = makeTmpDir();
     const buildDir = makeSplitBuildReport(tmp, { missingChild: true });
     expect(() => resolveBuildReport(buildDir)).toThrow('CHILD_FILE_MISSING');
+  });
+
+  it('TEST-026-030: throws INVALID_CHILD_PAYLOAD when split build child fields are malformed', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReportWithMalformedChild(tmp);
+    expect(() => resolveBuildReport(buildDir)).toThrow('INVALID_CHILD_PAYLOAD');
   });
 });
 

--- a/tests/spec-resolver.test.ts
+++ b/tests/spec-resolver.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { resolveSpec, resolveDiscover, detectFormat, resolveArtifactPaths, findArtifactPath } from '../src/lash/spec-resolver.js';
+import { resolveSpec, resolveDiscover, resolveTests, detectFormat, resolveArtifactPaths, findArtifactPath } from '../src/lash/spec-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -118,6 +118,67 @@ function makeSplitDiscover(tmpDir: string, opts?: { missingChild?: boolean }): s
   return dir;
 }
 
+function makeSingleTests(tmpDir: string): string {
+  const p = join(tmpDir, 'tests.json');
+  writeJson(p, {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    example_cases: [
+      { id: 'TEST-001', module_ref: 'MOD-001' },
+    ],
+    property_cases: [
+      { id: 'PROP-001', module_ref: 'MOD-001' },
+    ],
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: [],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+  });
+  return p;
+}
+
+function makeSplitTests(tmpDir: string, opts?: { missingChild?: boolean }): string {
+  const dir = join(tmpDir, 'tests');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: ['INV-001'],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+    modules: ['mod-001-alpha.json', 'mod-002-beta.json'],
+  });
+
+  if (!opts?.missingChild) {
+    writeJson(join(dir, 'mod-001-alpha.json'), {
+      example_cases: [{ id: 'TEST-001', module_ref: 'MOD-001' }],
+      property_cases: [{ id: 'PROP-001', module_ref: 'MOD-001' }],
+    });
+    writeJson(join(dir, 'mod-002-beta.json'), {
+      example_cases: [{ id: 'TEST-002', module_ref: 'MOD-002' }],
+      property_cases: [{ id: 'PROP-002', module_ref: 'MOD-002' }],
+    });
+  }
+
+  return dir;
+}
+
 // ---------------------------------------------------------------------------
 // detectFormat
 // ---------------------------------------------------------------------------
@@ -133,6 +194,12 @@ describe('detectFormat', () => {
     const tmp = makeTmpDir();
     const specDir = makeSplitSpec(tmp);
     expect(detectFormat(specDir)).toBe('split_directory');
+  });
+
+  it('TEST-026-018: returns split_directory for explicit index.json path', () => {
+    const tmp = makeTmpDir();
+    const specDir = makeSplitSpec(tmp);
+    expect(detectFormat(join(specDir, 'index.json'))).toBe('split_directory');
   });
 
   it('TEST-026-003: throws PATH_NOT_FOUND for non-existent path', () => {
@@ -225,6 +292,17 @@ describe('resolveSpec', () => {
     expect(hash1).toBe(hash2);
     expect(hash1).toHaveLength(64);
   });
+
+  it('TEST-026-019: explicit split spec index path matches directory behavior', () => {
+    const tmp = makeTmpDir();
+    const specDir = makeSplitSpec(tmp);
+
+    const byDir = resolveSpec(specDir);
+    const byIndex = resolveSpec(join(specDir, 'index.json'));
+
+    expect(byIndex.spec).toEqual(byDir.spec);
+    expect(byIndex.specHash).toBe(byDir.specHash);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,6 +347,58 @@ describe('resolveDiscover', () => {
     const tmp = makeTmpDir();
     const discoverDir = makeSplitDiscover(tmp, { missingChild: true });
     expect(() => resolveDiscover(discoverDir)).toThrow('CHILD_FILE_MISSING');
+  });
+
+  it('TEST-026-020: explicit split discover index path matches directory behavior', () => {
+    const tmp = makeTmpDir();
+    const discoverDir = makeSplitDiscover(tmp);
+
+    const byDir = resolveDiscover(discoverDir);
+    const byIndex = resolveDiscover(join(discoverDir, 'index.json'));
+
+    expect(byIndex.discover).toEqual(byDir.discover);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTests
+// ---------------------------------------------------------------------------
+
+describe('resolveTests', () => {
+  it('TEST-026-021: loads single file tests artifact', () => {
+    const tmp = makeTmpDir();
+    const testsPath = makeSingleTests(tmp);
+    const { tests } = resolveTests(testsPath);
+
+    expect(tests.example_cases).toHaveLength(1);
+    expect(tests.property_cases).toHaveLength(1);
+    expect(tests.coverage_summary).toBeDefined();
+  });
+
+  it('TEST-026-022: loads split tests artifact and merges module files', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTests(tmp);
+    const { tests } = resolveTests(testsDir);
+
+    expect(tests.example_cases).toHaveLength(2);
+    expect(tests.property_cases).toHaveLength(2);
+    expect(tests.coverage_guards).toBeDefined();
+  });
+
+  it('TEST-026-023: explicit split tests index path matches directory behavior', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTests(tmp);
+
+    const byDir = resolveTests(testsDir);
+    const byIndex = resolveTests(join(testsDir, 'index.json'));
+
+    expect(byIndex.tests).toEqual(byDir.tests);
+  });
+
+  it('TEST-026-024: throws CHILD_FILE_MISSING for missing split tests module file', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTests(tmp, { missingChild: true });
+    expect(() => resolveTests(testsDir)).toThrow('CHILD_FILE_MISSING');
   });
 });
 

--- a/tests/spec-resolver.test.ts
+++ b/tests/spec-resolver.test.ts
@@ -7,7 +7,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { resolveSpec, resolveDiscover, resolveTests, detectFormat, resolveArtifactPaths, findArtifactPath } from '../src/lash/spec-resolver.js';
+import { resolveSpec, resolveDiscover, resolveTests, resolveBuildReport, detectFormat, resolveArtifactPaths, findArtifactPath } from '../src/lash/spec-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -179,6 +179,81 @@ function makeSplitTests(tmpDir: string, opts?: { missingChild?: boolean }): stri
   return dir;
 }
 
+function makeSingleBuildReport(tmpDir: string): string {
+  const p = join(tmpDir, 'build_report.json');
+  writeJson(p, {
+    phase: 'build',
+    version: '4.0',
+    execution_plan: {
+      module_order: ['MOD-001'],
+      tracer_bullet_path: 'SCENARIO-001',
+      rationale: 'test',
+    },
+    tracer_bullet_result: { status: 'passed' },
+    module_results: [
+      { module_ref: 'MOD-001', status: 'completed', retry_history: [], auto_decisions: [] },
+    ],
+    test_summary: {
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      framework: 'vitest',
+    },
+    acceptance_result: {
+      scenarios_verified: ['SCENARIO-001'],
+      status: 'all_passed',
+      source: 'critic_agent',
+    },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+  });
+  return p;
+}
+
+function makeSplitBuildReport(tmpDir: string, opts?: { missingChild?: boolean }): string {
+  const dir = join(tmpDir, 'build');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    version: '4.0',
+    execution_plan: {
+      module_order: ['MOD-001', 'MOD-002'],
+      tracer_bullet_path: 'SCENARIO-001',
+      rationale: 'test',
+    },
+    tracer_bullet_result: { status: 'passed' },
+    test_summary: {
+      total: 3,
+      passed: 3,
+      failed: 0,
+      skipped: 0,
+      framework: 'vitest',
+    },
+    acceptance_result: {
+      scenarios_verified: ['SCENARIO-001'],
+      status: 'all_passed',
+      source: 'critic_agent',
+    },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+    modules: ['mod-001-alpha.json', 'mod-002-beta.json'],
+  });
+
+  if (!opts?.missingChild) {
+    writeJson(join(dir, 'mod-001-alpha.json'), {
+      module_results: [{ module_ref: 'MOD-001', status: 'completed', retry_history: [], auto_decisions: [] }],
+    });
+    writeJson(join(dir, 'mod-002-beta.json'), {
+      module_results: [{ module_ref: 'MOD-002', status: 'degraded', retry_history: [], auto_decisions: [] }],
+    });
+  }
+
+  return dir;
+}
 // ---------------------------------------------------------------------------
 // detectFormat
 // ---------------------------------------------------------------------------
@@ -399,6 +474,46 @@ describe('resolveTests', () => {
     const tmp = makeTmpDir();
     const testsDir = makeSplitTests(tmp, { missingChild: true });
     expect(() => resolveTests(testsDir)).toThrow('CHILD_FILE_MISSING');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBuildReport
+// ---------------------------------------------------------------------------
+
+describe('resolveBuildReport', () => {
+  it('TEST-026-025: loads single file build report artifact', () => {
+    const tmp = makeTmpDir();
+    const buildPath = makeSingleBuildReport(tmp);
+    const { buildReport } = resolveBuildReport(buildPath);
+
+    expect(buildReport.module_results).toHaveLength(1);
+    expect(buildReport.test_summary).toBeDefined();
+  });
+
+  it('TEST-026-026: loads split build report artifact and merges module files', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReport(tmp);
+    const { buildReport } = resolveBuildReport(buildDir);
+
+    expect(buildReport.module_results).toHaveLength(2);
+    expect(buildReport.test_summary).toBeDefined();
+  });
+
+  it('TEST-026-027: explicit split build index path matches directory behavior', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReport(tmp);
+
+    const byDir = resolveBuildReport(buildDir);
+    const byIndex = resolveBuildReport(join(buildDir, 'index.json'));
+
+    expect(byIndex.buildReport).toEqual(byDir.buildReport);
+  });
+
+  it('TEST-026-028: throws CHILD_FILE_MISSING for missing split build module file', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReport(tmp, { missingChild: true });
+    expect(() => resolveBuildReport(buildDir)).toThrow('CHILD_FILE_MISSING');
   });
 });
 

--- a/tests/spec-resolver.test.ts
+++ b/tests/spec-resolver.test.ts
@@ -208,6 +208,53 @@ function makeSplitTestsWithMalformedChild(tmpDir: string): string {
   return dir;
 }
 
+function makeSplitTestsWithoutModules(tmpDir: string): string {
+  const dir = join(tmpDir, 'tests');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: ['INV-001'],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+  });
+
+  return dir;
+}
+
+function makeSplitTestsWithInvalidModules(tmpDir: string): string {
+  const dir = join(tmpDir, 'tests');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    artifact: 'tests',
+    version: '4.0',
+    coverage_summary: {
+      requirements_covered: ['REQ-001'],
+      requirements_uncovered: [],
+      invariants_covered: ['INV-001'],
+      invariants_uncovered: [],
+    },
+    coverage_guards: {
+      invariants_uncovered_must_be_empty: true,
+      requirements_uncovered_must_be_empty: true,
+    },
+    modules: ['mod-001-alpha.json', 7],
+  });
+
+  return dir;
+}
+
 function makeSingleBuildReport(tmpDir: string): string {
   const p = join(tmpDir, 'build_report.json');
   writeJson(p, {
@@ -317,6 +364,73 @@ function makeSplitBuildReportWithMalformedChild(tmpDir: string): string {
 
   writeJson(join(dir, 'mod-001-alpha.json'), {
     module_results: { module_ref: 'MOD-001', status: 'completed' },
+  });
+
+  return dir;
+}
+
+function makeSplitBuildReportWithoutModules(tmpDir: string): string {
+  const dir = join(tmpDir, 'build');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    version: '4.0',
+    execution_plan: {
+      module_order: ['MOD-001'],
+      tracer_bullet_path: 'SCENARIO-001',
+      rationale: 'test',
+    },
+    tracer_bullet_result: { status: 'passed' },
+    test_summary: {
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      framework: 'vitest',
+    },
+    acceptance_result: {
+      scenarios_verified: ['SCENARIO-001'],
+      status: 'all_passed',
+      source: 'critic_agent',
+    },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+  });
+
+  return dir;
+}
+
+function makeSplitBuildReportWithInvalidModules(tmpDir: string): string {
+  const dir = join(tmpDir, 'build');
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'index.json'), {
+    phase: 'build',
+    version: '4.0',
+    execution_plan: {
+      module_order: ['MOD-001'],
+      tracer_bullet_path: 'SCENARIO-001',
+      rationale: 'test',
+    },
+    tracer_bullet_result: { status: 'passed' },
+    test_summary: {
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      framework: 'vitest',
+    },
+    acceptance_result: {
+      scenarios_verified: ['SCENARIO-001'],
+      status: 'all_passed',
+      source: 'critic_agent',
+    },
+    contract_amendments: [],
+    auto_decisions: [],
+    unresolved_issues: [],
+    modules: ['mod-001-alpha.json', ''],
   });
 
   return dir;
@@ -548,6 +662,18 @@ describe('resolveTests', () => {
     const testsDir = makeSplitTestsWithMalformedChild(tmp);
     expect(() => resolveTests(testsDir)).toThrow('INVALID_CHILD_PAYLOAD');
   });
+
+  it('TEST-026-031: throws INVALID_INDEX_PAYLOAD when split tests index omits modules', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTestsWithoutModules(tmp);
+    expect(() => resolveTests(testsDir)).toThrow('INVALID_INDEX_PAYLOAD');
+  });
+
+  it('TEST-026-032: throws INVALID_INDEX_PAYLOAD when split tests index modules contains invalid entries', () => {
+    const tmp = makeTmpDir();
+    const testsDir = makeSplitTestsWithInvalidModules(tmp);
+    expect(() => resolveTests(testsDir)).toThrow('INVALID_INDEX_PAYLOAD');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -593,6 +719,18 @@ describe('resolveBuildReport', () => {
     const tmp = makeTmpDir();
     const buildDir = makeSplitBuildReportWithMalformedChild(tmp);
     expect(() => resolveBuildReport(buildDir)).toThrow('INVALID_CHILD_PAYLOAD');
+  });
+
+  it('TEST-026-033: throws INVALID_INDEX_PAYLOAD when split build index omits modules', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReportWithoutModules(tmp);
+    expect(() => resolveBuildReport(buildDir)).toThrow('INVALID_INDEX_PAYLOAD');
+  });
+
+  it('TEST-026-034: throws INVALID_INDEX_PAYLOAD when split build index modules contains invalid entries', () => {
+    const tmp = makeTmpDir();
+    const buildDir = makeSplitBuildReportWithInvalidModules(tmp);
+    expect(() => resolveBuildReport(buildDir)).toThrow('INVALID_INDEX_PAYLOAD');
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize artifact entry handling so explicit `index.json` paths are treated the same as split artifact directories for `spec`, `discover`, `tests`, and build report ingestion
- add regression coverage for `lash plan`, `lash package --tests`, and profile writer so split artifacts loaded via `index.json` no longer bypass assembly
- update the Chinese user guide and progress log to document the expanded artifact path support

## Verification
- `pnpm test tests/spec-resolver.test.ts tests/plan-generator.test.ts tests/cli.test.ts src/profile/__tests__/writer.test.ts`
- `pnpm lint`
- `pnpm build`

## Related
- #78