### PR TITLE
fix: enforce discover review gate contracts

### DIFF
--- a/commands/critic/discover.md
+++ b/commands/critic/discover.md
@@ -9,7 +9,7 @@
 
 ## Input
 
-- `specs/discover.json` or `specs/discover/index.json`
+- `specs/discover.json` or `specs/discover/index.json`, or the feature-scoped equivalent under `specs/features/feat-{featureSlug}/`
 
 ---
 
@@ -62,7 +62,7 @@ For EACH acceptance criterion (`REQ-xxx-AC-n`):
 
 ## Output
 
-Write to `specs/discover_review.json`:
+Write to `specs/discover_review.json` in greenfield mode, or `specs/features/feat-{featureSlug}/discover_review.json` in feature mode:
 
 ```json
 {
@@ -153,7 +153,7 @@ Note: `global_coherence_check` is filled by the Supervisor agent, not by you. Le
 ## On Issue
 
 1. Attempt to fix the discover artifact — adjust unclear requirements, add missing invariants, tighten vague acceptance criteria.
-2. **You may ONLY modify the discover artifact (`specs/discover.json` or files under `specs/discover/`). You must NEVER invent new requirements or change the user's intent — only sharpen existing ones.**
+2. **You may ONLY modify the current discover artifact root (`specs/discover.json` or files under `specs/discover/`, or the feature-scoped equivalent under `specs/features/feat-{featureSlug}/`). You must NEVER invent new requirements or change the user's intent — only sharpen existing ones.**
 3. After fix, a fresh Critic instance re-runs verification from the top (no prior-cycle context).
 4. If fix succeeds: record what was fixed in `self_fix_log`, mark all checks as passed.
 5. If still failing after reaching the self-fix cap:

--- a/commands/critic/spec.md
+++ b/commands/critic/spec.md
@@ -9,8 +9,8 @@
 
 ## Input
 
-- `specs/discover.json` or `specs/discover/index.json`
-- `specs/spec.json` or `specs/spec/index.json`
+- `discover.json` or `discover/index.json` under the current artifact root
+- `spec.json` or `spec/index.json` under the current artifact root
 
 ---
 
@@ -38,7 +38,7 @@ Scan the spec artifact for any user-facing behavior (not technical behavior like
 
 ## Output
 
-Write to `specs/spec_review.json`:
+Write to `spec_review.json` under the current artifact root (`specs/spec_review.json` in greenfield mode, or `specs/features/feat-{featureSlug}/spec_review.json` in feature mode):
 
 ```json
 {
@@ -123,7 +123,7 @@ Perform an additional **Impact Audit** after the standard backward verification:
 3. **Dependency Direction Changes**: Check whether any new `dependency_graph` edges in the spec introduce direction reversals (A→B where B→A already exists in L1) or new cross-layer dependencies.
 4. **Breaking Changes**: Any change that would require callers of an existing interface to be updated is a breaking change.
 
-Record the impact audit result in `specs/features/feat-xxx/spec_review.json` under the `impact_audit` field:
+Record the impact audit result in the current artifact root's `spec_review.json` under the `impact_audit` field:
 
 ```json
 {
@@ -148,7 +148,7 @@ This step applies only when `mode=feature` and L1 profile is available. In green
 ## On Issue
 
 1. Attempt to fix the spec artifact to align with the discover artifact.
-2. **You may ONLY modify the spec artifact (`specs/spec.json` or files under `specs/spec/`). You must NEVER modify upstream artifacts.**
+2. **You may ONLY modify the current spec artifact root (`specs/spec.json` or files under `specs/spec/`, or the feature-scoped equivalent under `specs/features/feat-{featureSlug}/`). You must NEVER modify upstream artifacts.**
 3. After fix, a fresh Critic instance re-runs verification from the top (no prior-cycle context).
 4. If fix succeeds: record what was fixed in `self_fix_log`, mark passed.
 5. If still failing after reaching the self-fix cap:

--- a/commands/discover/SKILL.md
+++ b/commands/discover/SKILL.md
@@ -159,8 +159,8 @@ Dispatch subagent → `commands/discover/artifact-writer.md`. Present only the f
 
 <!-- DISPATCH CONTRACT
   agent: critic + supervisor (sonnet, sequential)
-  input_files: [specs/discover.json OR specs/discover/index.json]
-  output_file: specs/discover_review.json
+  input_files: [specs/discover.json OR specs/discover/index.json OR specs/features/feat-{featureSlug}/discover.json OR specs/features/feat-{featureSlug}/discover/index.json]
+  output_file: specs/discover_review.json OR specs/features/feat-{featureSlug}/discover_review.json
   output_summary: { passed, block_count, warn_count, drift_detected, aligned } (max 20 logical entries)
   on_error: pause and present findings to user; wait for resolution
 -->

--- a/commands/discover/SKILL.md
+++ b/commands/discover/SKILL.md
@@ -149,7 +149,11 @@ After Layer 3 approved → Artifact Generation:
   on_error: standard
 -->
 
-Dispatch subagent → `commands/discover/artifact-writer.md`. Present confirmation.
+Dispatch subagent → `commands/discover/artifact-writer.md`. Present only the file-write confirmation.
+
+**Do NOT stop here.** Discover is **not complete** after Layer 3 or artifact writing. Do NOT generate extra files, do NOT inline any review, and do NOT tell the user to run `/spec` yet.
+
+**Next: mandatory Critic + Supervisor dispatch.** The very next step after artifact writing is the independent review gate below.
 
 ### Critic + Supervisor Dispatch
 
@@ -163,6 +167,8 @@ Dispatch subagent → `commands/discover/artifact-writer.md`. Present confirmati
 ```
 Use the Skill tool to load: commands/discover/critic-supervisor.md
 ```
+
+Only after a **fresh independent Critic pass** and an **aligned Supervisor result** may the main agent present discover as complete and mention `/spec` as the next stage.
 
 **Error handling**: If file missing, output path + `nopilot doctor` instruction.
 

--- a/commands/discover/artifact-writer.md
+++ b/commands/discover/artifact-writer.md
@@ -5,13 +5,16 @@
 
 You are a subagent. Your job: read the current discover artifact state and finalize all JSON files. Do NOT interact with the user directly. Return a brief confirmation summary to the main agent.
 
+This step does **not** complete `/discover`. Do NOT tell the user to run `/spec`, do NOT emit a completion message, and do NOT bypass the mandatory Critic + Supervisor review gate that follows.
+
 ### Feature Mode: Artifact Output Path
 
-**If `mode=feature`**: Write all artifacts to `specs/features/feat-{featureSlug}/` instead of `specs/`. Specifically:
+**If `mode=feature`**: Write the discover-stage artifacts to `specs/features/feat-{featureSlug}/` instead of `specs/`. Specifically:
 - `specs/features/feat-{featureSlug}/discover.json` (or split: `specs/features/feat-{featureSlug}/discover/index.json`)
 - `specs/features/feat-{featureSlug}/discover_history.json`
-- `specs/features/feat-{featureSlug}/discover_review.json`
 - Mockups (if UI Taste ran): `specs/features/feat-{featureSlug}/mockups/`
+
+`specs/features/feat-{featureSlug}/discover_review.json` is **not** written by this artifact writer. It is created later by the mandatory independent Critic + Supervisor review gate.
 
 In the discover artifact, add a `profile_ref` field pointing to the project profile:
 ```json
@@ -20,7 +23,7 @@ In the discover artifact, add a `profile_ref` field pointing to the project prof
 Feature artifacts reference the profile by path — they do not copy profile data into the feature artifact.
 
 After writing, output:
-> "Feature discover artifacts written to specs/features/feat-{featureSlug}/. Run /spec to continue."
+> "Feature discover artifacts written to specs/features/feat-{featureSlug}/. Main agent must now trigger Critic + Supervisor review before presenting completion or `/spec`."
 
 **If `mode=greenfield`**: Write artifacts to `specs/` as defined below.
 
@@ -207,4 +210,4 @@ written: [list of file paths written]
 format: single | split
 ```
 
-Keep total output under 500 chars. The main agent will present the completion message to the user.
+Keep total output under 500 chars. The main agent may present the completion message to the user only after Critic + Supervisor both pass.

--- a/commands/discover/critic-supervisor.md
+++ b/commands/discover/critic-supervisor.md
@@ -13,7 +13,15 @@
 
 ## Critic Integration
 
-After both artifact files are written, spawn the Critic agent for independent requirement quality verification.
+After both artifact files are written, the main discover flow MUST immediately enter this review gate. Discover is not complete after artifact generation alone.
+
+The main discover flow MUST NOT:
+- inline the Critic review or Supervisor review in the main agent,
+- manually mark `passed: true`, `aligned: true`, or any equivalent success field,
+- tell the user to continue to `/spec`,
+- generate extra completion files/messages before this review gate passes.
+
+Spawn the Critic agent for independent requirement quality verification.
 
 <!-- DISPATCH CONTRACT
   agent: critic (sonnet)
@@ -34,8 +42,10 @@ After both artifact files are written, spawn the Critic agent for independent re
    - **Acceptance criteria testability** — can concrete tests be derived directly?
    - **Requirement coverage** — are all core scenarios covered? Any orphan requirements?
 4. Critic writes results to `specs/discover_review.json`
-5. **If issues found:** Critic attempts self-fix on the discover artifact, then re-verifies with a fresh Critic instance using the floating complexity-based cap from `<%=CRITIC_PATH%>`. If still failing after the cap and trend evaluation, pause and present findings to user.
-6. **If passed:** Proceed to Supervisor check.
+5. **If issues found:** Critic attempts self-fix on the discover artifact, records the attempt in `discover_review.json.self_fix_log`, then re-verifies with a fresh Critic instance using the floating complexity-based cap from `<%=CRITIC_PATH%>`.
+6. The main discover flow MUST NOT treat self-fixed output as passed until that fresh Critic instance writes a passing review.
+7. If still failing after the cap and trend evaluation, pause and present findings to user.
+8. **If passed:** Proceed to Supervisor check.
 
 ### 6Cs Grading: Mandatory vs Advisory
 
@@ -67,11 +77,13 @@ After Critic completes, read `specs/discover_review.json` and check:
 
 If all four pass → proceed to Supervisor. If any failed and Critic's self-fix was exhausted → pause, present the review findings to the user, wait for resolution.
 
+The main discover flow MUST NOT manually rewrite those pass/fail fields to force progression.
+
 ---
 
 ## Supervisor Integration
 
-After Critic passes (or user resolves Critic findings):
+After Critic passes:
 
 <!-- DISPATCH CONTRACT
   agent: supervisor (sonnet)
@@ -94,4 +106,6 @@ After Critic passes (or user resolves Critic findings):
 4. Supervisor checks global coherence: does the requirement set match the stated intent?
 5. Write the Supervisor's assessment into `specs/discover_review.json`'s `global_coherence_check` field
 6. **If drift detected:** Pause, present the drift diagnosis to the user, and wait for resolution before proceeding
-7. **If aligned:** Proceed — output the completion message from `artifact-writer.md`
+7. **If aligned:** Proceed — only now may the main agent present discover as complete and mention `/spec` as the next stage.
+
+If the user resolves Critic findings manually after a failed review, the main discover flow MUST re-run Critic and wait for a fresh passing review before entering Supervisor.

--- a/commands/discover/critic-supervisor.md
+++ b/commands/discover/critic-supervisor.md
@@ -25,9 +25,9 @@ Spawn the Critic agent for independent requirement quality verification.
 
 <!-- DISPATCH CONTRACT
   agent: critic (sonnet)
-  input_files: [specs/discover.json OR specs/discover/index.json]
+  input_files: [specs/discover.json OR specs/discover/index.json OR specs/features/feat-{featureSlug}/discover.json OR specs/features/feat-{featureSlug}/discover/index.json]
   input_state: []
-  output_file: specs/discover_review.json
+  output_file: specs/discover_review.json OR specs/features/feat-{featureSlug}/discover_review.json
   output_summary: { passed: bool, block_count: number, warn_count: number, 6cs_audit: { passed: bool }, invariant_verification: { passed: bool }, acceptance_criteria_verification: { passed: bool }, coverage_verification: { passed: bool } } (max 20 logical entries)
   on_error: pause and present findings to user; do not proceed to Supervisor
 -->
@@ -35,13 +35,13 @@ Spawn the Critic agent for independent requirement quality verification.
 ### Critic Dispatch Instructions
 
 1. Spawn Critic agent using the Agent tool targeting `<%=CRITIC_PATH%>`
-2. Critic reads only the discover artifact (`specs/discover.json` or `specs/discover/index.json`) — no conversation history, independent session
+2. Critic reads only the discover artifact (`specs/discover.json` or `specs/discover/index.json`, or the feature-scoped equivalent) — no conversation history, independent session
 3. Critic performs four checks:
    - **6Cs quality audit** — independently evaluate each requirement's 6Cs dimensions (see grading below)
    - **Invariant verification** — completeness, non-contradiction, scope accuracy
    - **Acceptance criteria testability** — can concrete tests be derived directly?
    - **Requirement coverage** — are all core scenarios covered? Any orphan requirements?
-4. Critic writes results to `specs/discover_review.json`
+4. Critic writes results to the matching `discover_review.json` under the current artifact root
 5. **If issues found:** Critic attempts self-fix on the discover artifact, records the attempt in `discover_review.json.self_fix_log`, then re-verifies with a fresh Critic instance using the floating complexity-based cap from `<%=CRITIC_PATH%>`.
 6. The main discover flow MUST NOT treat self-fixed output as passed until that fresh Critic instance writes a passing review.
 7. If still failing after the cap and trend evaluation, pause and present findings to user.
@@ -69,7 +69,7 @@ In `discover_review.json`, Critic records advisory failures with `"severity": "w
 
 ### Checkpoint: Read discover_review.json
 
-After Critic completes, read `specs/discover_review.json` and check:
+After Critic completes, read the matching `discover_review.json` under the current artifact root and check:
 - `6cs_audit.passed == true` (only `"block"` severity issues count toward pass/fail)
 - `invariant_verification.passed == true`
 - `acceptance_criteria_verification.passed == true`
@@ -87,9 +87,9 @@ After Critic passes:
 
 <!-- DISPATCH CONTRACT
   agent: supervisor (sonnet)
-  input_files: [specs/discover.json OR specs/discover/index.json, specs/discover_review.json]
+  input_files: [specs/discover.json OR specs/discover/index.json OR specs/features/feat-{featureSlug}/discover.json OR specs/features/feat-{featureSlug}/discover/index.json, specs/discover_review.json OR specs/features/feat-{featureSlug}/discover_review.json]
   input_state: [constraints, selected_direction, tech_direction, design_philosophy]
-  output_file: specs/discover_review.json (global_coherence_check field)
+  output_file: specs/discover_review.json OR specs/features/feat-{featureSlug}/discover_review.json (global_coherence_check field)
   output_summary: { drift_detected: bool, drift_score: number, drift_diagnosis: string, aligned: bool } (max 20 logical entries)
   on_error: pause and present drift diagnosis to user; wait for resolution before proceeding
 -->
@@ -102,9 +102,9 @@ After Critic passes:
    - `selected_direction`
    - `tech_direction`
    - `design_philosophy`
-3. Pass the complete discover artifact (`specs/discover.json` or `specs/discover/index.json`) as the **current stage output**
+3. Pass the complete discover artifact (greenfield or feature-scoped) as the **current stage output**
 4. Supervisor checks global coherence: does the requirement set match the stated intent?
-5. Write the Supervisor's assessment into `specs/discover_review.json`'s `global_coherence_check` field
+5. Write the Supervisor's assessment into the matching `discover_review.json`'s `global_coherence_check` field
 6. **If drift detected:** Pause, present the drift diagnosis to the user, and wait for resolution before proceeding
 7. **If aligned:** Proceed — only now may the main agent present discover as complete and mention `/spec` as the next stage.
 

--- a/commands/spec/SKILL.md
+++ b/commands/spec/SKILL.md
@@ -22,9 +22,11 @@ You are performing constrained design expansion. Module decomposition, interface
 
 ## Input
 
-Verify that a discover artifact exists (`specs/discover.json` or `specs/discover/index.json`). If missing, inform the user: "Run /discover first to generate the discover artifact." and halt.
+Verify that a discover artifact exists (`specs/discover.json`, `specs/discover/index.json`, `specs/features/feat-{featureSlug}/discover.json`, or `specs/features/feat-{featureSlug}/discover/index.json`). If missing, inform the user: "Run /discover first to generate the discover artifact." and halt.
 
-Read the discover artifact. If it is split, read `specs/discover/index.json` first, then load `requirements.json`, `scenarios.json`, and `history.json` as needed. Check the artifact's `mode` to determine full or lite behavior.
+Read the discover artifact from its artifact root. Use that same artifact root for all `/spec` outputs (`spec.json`, `spec_review.json`, and `decisions.json`). Before Phase 1, read the matching `discover_review.json` from that root (`specs/discover_review.json` or `specs/features/feat-{featureSlug}/discover_review.json`). If it is missing, or if any of `6cs_audit.passed`, `invariant_verification.passed`, `acceptance_criteria_verification.passed`, or `coverage_verification.passed` is not `true`, or if `global_coherence_check.intent_alignment != "aligned"`, inform the user: "Finish `/discover` review before running `/spec`." and halt.
+
+If the discover artifact is split, read `index.json` first, then load `requirements.json`, `scenarios.json`, and `history.json` as needed. Check the artifact's `mode` to determine full or lite behavior.
 If `specs/build_report.json` or `specs/build/index.json` exists (backtrack from /build), read it too for diagnostic context.
 
 ### Feature Mode: Code Awareness

--- a/commands/spec/decisions.md
+++ b/commands/spec/decisions.md
@@ -2,7 +2,7 @@
 
 # spec/decisions — Phase 5: Decision Ledger
 
-Append this stage's auto_decisions to `specs/decisions.json` (create if not exists). This file is the unified decision audit trail across all stages.
+Append this stage's auto_decisions to `decisions.json` under the current artifact root (`specs/decisions.json` in greenfield mode, or `specs/features/feat-{featureSlug}/decisions.json` in feature mode). Create the file if it does not exist. This file is the unified decision audit trail across all stages within that artifact root.
 
 ```json
 {
@@ -25,4 +25,4 @@ If the file already exists (e.g., from a previous /discover run), **append** to 
 
 After appending:
 
-> "spec artifacts written to specs/. Generate visualization by running: open specs/views/spec.html (or run /visualize for full dashboard). Run /build to continue."
+> "spec artifacts written to the current artifact root. Run /visualize for the dashboard, then run /build to continue."

--- a/commands/spec/review-runner.md
+++ b/commands/spec/review-runner.md
@@ -3,6 +3,8 @@
 
 # spec/review-runner — Phase 3: Critic + Supervisor Dispatch
 
+When `/spec` is running from a feature-scoped discover artifact, read and write review artifacts under the same feature artifact root. Greenfield mode uses `specs/`.
+
 After writing spec.json, spawn two independent review agents. These agents run in **separate sessions with no access to the generation conversation history** — this separation is critical to prevent self-approval bias.
 
 ## DISPATCH CONTRACT — Critic Agent
@@ -13,8 +15,8 @@ agent: Critic
 skill: <%=CRITIC_PATH%>
 session: independent (no conversation history)
 reads:
-  - specs/discover.json OR specs/discover/index.json
-  - specs/spec.json OR specs/spec/index.json
+  - discover.json OR discover/index.json under the current artifact root
+  - spec.json OR spec/index.json under the current artifact root
 must NOT read: generation conversation history
 task:
   - Perform backward verification: for each acceptance criterion, can the spec satisfy it?
@@ -22,19 +24,20 @@ task:
   - Use floating iteration cap based on review complexity: simple=3, medium=5, complex=7-10
   - Each self-fix iteration is reverified by a new Critic instance (no carry-over context)
   - If cap reached, evaluate trend (converging / diverging / oscillating) to decide next action
-writes: specs/spec_review.json
+writes: spec_review.json under the current artifact root
 output_summary: { passed: bool, block_count: number, warn_count: number, backward_verification: { passed: bool }, undeclared_behaviors: [...] } (max 20 logical entries)
 ```
 
 **Critic Agent** (independent session, no conversation history):
 - Spawn `<%=CRITIC_PATH%>` using the Agent tool in a **fresh session**
 - Critic reads only the discover artifact and spec artifact (`specs/discover.json` or `specs/discover/index.json`; `specs/spec.json` or `specs/spec/index.json`) — never the generation conversation
+- Critic reads only the discover artifact and spec artifact under the current artifact root — never the generation conversation
 - Performs backward verification: for each acceptance criterion, can the spec satisfy it?
 - Checks for undeclared core behaviors
 - Uses a floating iteration cap (not a fixed number) based on review complexity — simple: 3, medium: 5, complex: 7-10
 - Each self-fix iteration is reverified by a **new Critic instance** (no carry-over context from previous cycles)
 - If the cap is reached, evaluates the trend (converging / diverging / oscillating) to decide next action
-- Results written to specs/spec_review.json
+- Results written to `spec_review.json` under the current artifact root
 
 ## DISPATCH CONTRACT — Supervisor Agent
 
@@ -44,23 +47,23 @@ agent: Supervisor
 skill: <%=SUPERVISOR_PATH%>
 session: independent (no conversation history)
 reads:
-  - specs/discover.json OR specs/discover/index.json  [anchor: constraints + selected_direction + tech_direction]
-  - specs/spec.json OR specs/spec/index.json           [current stage output]
+  - discover.json OR discover/index.json under the current artifact root  [anchor: constraints + selected_direction + tech_direction]
+  - spec.json OR spec/index.json under the current artifact root           [current stage output]
   - discover.json design_philosophy field
-  - specs/decisions.json                               [cumulative decision audit trail, if present]
+  - decisions.json under the current artifact root     [cumulative decision audit trail, if present]
 must NOT read: generation conversation history
 task:
   - Use quantitative drift scoring (0-100)
   - Check global coherence: has complexity bloated? Does design still match intent?
-writes: spec_review.json global_coherence_check field
+writes: spec_review.json under the current artifact root (global_coherence_check field)
 output_summary: { drift_detected: bool, drift_score: number, drift_diagnosis: string, aligned: bool } (max 20 logical entries)
 ```
 
 **Supervisor Agent** (independent session, no conversation history):
 - Spawn `<%=SUPERVISOR_PATH%>` using the Agent tool in a **fresh session**
 - Pass the following from the discover artifact as the **anchor**: `constraints` + `selected_direction` + `tech_direction`
-- Pass the spec artifact (`specs/spec.json` or `specs/spec/index.json`) as the **current stage output**
-- Supervisor also reads `design_philosophy` from discover.json and `specs/decisions.json` (the cumulative decision audit trail) for drift analysis
+- Pass the spec artifact under the current artifact root as the **current stage output**
+- Supervisor also reads `design_philosophy` from discover.json and `decisions.json` under that same root for drift analysis
 - Uses quantitative drift scoring (0-100) rather than binary judgment — see supervisor skill for score ranges and recommended actions
 - Checks global coherence: has complexity bloated? Does the design still match intent?
-- Results written to spec_review.json global_coherence_check field
+- Results written to `spec_review.json` under the current artifact root in the `global_coherence_check` field

--- a/commands/spec/schema.md
+++ b/commands/spec/schema.md
@@ -2,10 +2,12 @@
 
 # spec/schema — Phase 2 Artifact Generation
 
+When `/spec` is running from a feature-scoped discover artifact, write all spec artifacts to the same feature artifact root (`specs/features/feat-{featureSlug}/`). Greenfield mode writes to `specs/`.
+
 Write the spec artifact. For small projects, use a single file. For larger projects with many modules, use a directory structure:
 
-- **Single file:** `specs/spec.json` — suitable when the module count is small
-- **Directory structure:** `specs/spec/index.json` + `specs/spec/mod-{id}-{name}.json` — suitable when the module count is large. `index.json` contains the top-level structure (dependency_graph, external_dependencies, global_error_strategy, auto_decisions, contract_amendments, context_dependencies) and a `module_refs` array listing the module file names. Each `mod-{id}-{name}.json` contains a single module definition.
+- **Single file:** `spec.json` under the current artifact root — suitable when the module count is small
+- **Directory structure:** `spec/index.json` + `spec/mod-{id}-{name}.json` under the current artifact root — suitable when the module count is large. `index.json` contains the top-level structure (dependency_graph, external_dependencies, global_error_strategy, auto_decisions, contract_amendments, context_dependencies) and a `module_refs` array listing the module file names. Each `mod-{id}-{name}.json` contains a single module definition.
 
 Use the following structure (shown as single-file format; directory format splits modules into separate files):
 
@@ -81,7 +83,7 @@ Use the following structure (shown as single-file format; directory format split
     }
   ],
   "contract_amendments": [],
-  "context_dependencies": ["specs/discover.json or specs/discover/index.json"]
+  "context_dependencies": ["discover.json or discover/index.json under the current artifact root"]
 }
 ```
 

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -150,3 +150,19 @@
 - 值得深入研究的问题:
   - 是否应在 `workflow.json` 与用户文档中把 `/spec` 的输入依赖显式提升为“discover artifact + discover review artifact”
   - 是否应为 discover/spec review artifact 增加 root/hash 绑定，防止人工修改 discover 后继续复用陈旧 review
+
+## Progress Snapshot: 2026-04-10 19:20
+- 触发方式: 为 ULTRAWORK 完成性验收补充可审计证据
+- 代码统计: 本次未改业务合同，仅补充验证与 review 证据记录
+- 当前版本: V0.0.6 缺陷修复中
+- 当前分支: `fix/issue-48-58-69-70-discover-review`
+- 本次工作:
+  - 再次执行并通过定向结构测试：`pnpm test src/skill-engine/__tests__/skill-structure.test.ts`
+  - 在当前 worktree 再次执行并通过全量验证：`pnpm test`、`pnpm lint`、`pnpm build`
+  - 清理本地产生的 `.benchmark/` 未跟踪测试产物，确认工作树恢复干净状态
+  - 追加子代理终审证据：快速子代理复核认为 PR #80 当前阻塞已关闭、范围内无新 blocker，且 GitHub 状态为 `mergeStateStatus: CLEAN`
+  - 记录 Oracle 终审的关键结论：代码修补方向正确，先前未通过完成性验收的原因是“审计证据不足”，而非“仍有代码阻塞”
+- 当前问题:
+  - GitHub 侧仍显示 `gh pr checks 80` 为 `no checks reported`；本轮验收依赖本地完整验证日志与子代理/Oracle 复核证据，而非远端 CI 记录
+- 值得深入研究的问题:
+  - 是否需要把 review 子代理与本地验证结果自动沉淀为仓库内标准化验收记录，避免后续 ULTRAWORK/Oracle 验收时再次因“证据不集中”被卡住

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -131,3 +131,22 @@
 - 值得深入研究的问题:
   - 是否应把“主流程不得手工写 passed/aligned、必须等待独立 review artifact”沉淀成跨 discover/spec/build 的统一结构测试模板
   - 是否需要在 `workflow.json` 或 schema 层新增更显式的 review-gate 完成信号，减少 prompt 文本与 artifact 状态机之间的歧义
+
+## Progress Snapshot: 2026-04-10 18:45
+- 触发方式: 根据 PR #80 review 与 Oracle 复核继续修补 merge blocker
+- 代码统计: 本次继续修改 prompt contract 与结构测试，未触碰 TypeScript 运行时代码
+- 当前版本: V0.0.6 缺陷修复中
+- 当前分支: `fix/issue-48-58-69-70-discover-review`
+- 本次工作:
+  - 在 `commands/spec/SKILL.md` 增加 discover review 硬门禁：`/spec` 现在必须读取同一 artifact root 下的 `discover_review.json`，并校验四个 Critic pass 字段与 `global_coherence_check.intent_alignment == "aligned"`
+  - 将 `commands/discover/SKILL.md`、`commands/discover/critic-supervisor.md`、`commands/critic/discover.md` 的 discover review 输入/输出路径统一为 greenfield 与 feature 共用“current artifact root”模型
+  - 将 `commands/spec/schema.md`、`commands/spec/review-runner.md`、`commands/spec/decisions.md`、`commands/critic/spec.md` 改为沿用当前 artifact root，避免 feature discover 驱动下仍回写全局 `specs/`
+  - 在 `src/skill-engine/__tests__/skill-structure.test.ts` 补充 `/spec` gate、feature-aware review path、spec artifact root 一致性的结构回归断言
+- 下一步计划:
+  - 先运行 `skill-structure` 定向测试，确认新增合同断言全部落地
+  - 若定向测试通过，再运行 `pnpm test`、`pnpm lint`、`pnpm build`，最后交给子代理做代码审查
+- 当前问题:
+  - LSP 本地缺少 `typescript-language-server`，无法用 LSP 直接做 TypeScript 诊断，只能依赖测试与构建验证
+- 值得深入研究的问题:
+  - 是否应在 `workflow.json` 与用户文档中把 `/spec` 的输入依赖显式提升为“discover artifact + discover review artifact”
+  - 是否应为 discover/spec review artifact 增加 root/hash 绑定，防止人工修改 discover 后继续复用陈旧 review

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -111,3 +111,23 @@
   - `resolveDiscover()` 仍未对 split child 内容做 schema 级结构校验，只保证文件存在且 JSON 可解析
 - 值得深入研究的问题:
   - 是否应在 resolver 层统一接入 artifact schema 校验，以便将 discover/spec/tests/build 的结构错误统一前置到加载阶段
+
+## Progress Snapshot: 2026-04-10 14:45
+- 触发方式: 修复 discover review gate 相关 issue #69 / #70 / #48 / #58
+- 代码统计: 本次未改运行时代码，收紧 `discover` prompt 合同并补充结构测试
+- 当前版本: V0.0.6 缺陷修复中
+- 当前分支: `fix/issue-48-58-69-70-discover-review`
+- 本次工作:
+  - 将 `commands/discover/SKILL.md` 明确改为：Layer 3 与 artifact 写入后不得视为 discover 完成，下一步必须进入 Critic + Supervisor review gate
+  - 将 `commands/discover/critic-supervisor.md` 明确改为：禁止主代理内联 Critic/Supervisor、禁止手工写 `passed/aligned` 通过、Critic 自修复后必须由 fresh Critic 复检
+  - 将 `commands/discover/artifact-writer.md` 去掉提前提示 `Run /spec to continue.` 的放行文案，改为仅回传写入确认并等待 review gate 完成
+  - 在 `src/skill-engine/__tests__/skill-structure.test.ts` 增加回归断言，锁定上述 discover review 合同
+  - 根据独立复核继续收紧边界：`artifact-writer` 不再宣称写入 `discover_review.json`，且 `critic-supervisor` 明确“用户手工处理发现的问题后也必须先拿到 fresh Critic pass，才能进入 Supervisor”
+- 下一步计划:
+  - 重新运行 `skill-structure` 定向测试与类型检查，确认 Oracle 指出的剩余两处合同缺口已被锁定
+  - 若重新验证通过，再复核全量测试 / build 结果与变更概况
+- 当前问题:
+  - `README_AGENT.md` 与部分旧说明仍保留 lite/spec 的 same-session Critic 叙述；本次 issue 目标集中在 discover，后续是否统一口径仍需单独决策
+- 值得深入研究的问题:
+  - 是否应把“主流程不得手工写 passed/aligned、必须等待独立 review artifact”沉淀成跨 discover/spec/build 的统一结构测试模板
+  - 是否需要在 `workflow.json` 或 schema 层新增更显式的 review-gate 完成信号，减少 prompt 文本与 artifact 状态机之间的歧义

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -656,4 +656,64 @@ describe('Context budget e2e tests (PR #60)', () => {
     expect(content).toContain('MUST re-run Critic and wait for a fresh passing review before entering Supervisor');
     expect(content).not.toContain('After Critic passes (or user resolves Critic findings):');
   });
+
+  it('TEST-070-014: /spec requires a passing discover review before Phase 1', () => {
+    const content = readFile('commands/spec/SKILL.md');
+
+    expect(content).toContain('discover_review.json');
+    expect(content).toContain('Finish `/discover` review before running `/spec`.');
+    expect(content).toContain('6cs_audit.passed');
+    expect(content).toContain('invariant_verification.passed');
+    expect(content).toContain('acceptance_criteria_verification.passed');
+    expect(content).toContain('coverage_verification.passed');
+    expect(content).toContain('global_coherence_check.intent_alignment');
+  });
+
+  it('TEST-070-015: /spec discover review gate is feature-aware', () => {
+    const content = readFile('commands/spec/SKILL.md');
+
+    expect(content).toContain('specs/features/feat-{featureSlug}/discover.json');
+    expect(content).toContain('specs/features/feat-{featureSlug}/discover_review.json');
+    expect(content).toContain('artifact root');
+  });
+
+  it('TEST-070-016: discover review contracts use feature-aware paths', () => {
+    const discoverSkill = readFile('commands/discover/SKILL.md');
+    const criticSupervisor = readFile('commands/discover/critic-supervisor.md');
+    const criticDiscover = readFile('commands/critic/discover.md');
+
+    expect(discoverSkill).toContain('specs/features/feat-{featureSlug}/discover_review.json');
+    expect(criticSupervisor).toContain('specs/features/feat-{featureSlug}/discover_review.json');
+    expect(criticDiscover).toContain('specs/features/feat-{featureSlug}/discover_review.json');
+  });
+
+  it('TEST-070-017: discover review reads and writes stay on the current artifact root', () => {
+    const criticSupervisor = readFile('commands/discover/critic-supervisor.md');
+    const criticDiscover = readFile('commands/critic/discover.md');
+
+    expect(criticSupervisor).toContain('matching `discover_review.json` under the current artifact root');
+    expect(criticDiscover).toContain('in greenfield mode, or `specs/features/feat-{featureSlug}/discover_review.json` in feature mode');
+    expect(criticDiscover).toContain('feature-scoped equivalent under `specs/features/feat-{featureSlug}/`');
+  });
+
+  it('TEST-070-018: /spec sub-skills keep spec artifacts on the current artifact root', () => {
+    const schemaContent = readFile('commands/spec/schema.md');
+    const reviewRunnerContent = readFile('commands/spec/review-runner.md');
+    const decisionsContent = readFile('commands/spec/decisions.md');
+
+    expect(schemaContent).toContain('same feature artifact root');
+    expect(schemaContent).toContain('`spec.json` under the current artifact root');
+    expect(reviewRunnerContent).toContain('spec_review.json under the current artifact root');
+    expect(reviewRunnerContent).toContain('decisions.json under the current artifact root');
+    expect(decisionsContent).toContain('specs/features/feat-{featureSlug}/decisions.json');
+    expect(decisionsContent).toContain('current artifact root');
+  });
+
+  it('TEST-070-019: critic spec contract is feature-aware for spec review artifacts', () => {
+    const content = readFile('commands/critic/spec.md');
+
+    expect(content).toContain('discover.json` or `discover/index.json` under the current artifact root');
+    expect(content).toContain('specs/features/feat-{featureSlug}/spec_review.json');
+    expect(content).toContain('current artifact root');
+  });
 });

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -558,6 +558,22 @@ describe('Context budget e2e tests (PR #60)', () => {
     expect(content).toMatch(/format:\s*single\s*\|\s*split/);
   });
 
+  it('TEST-070-005a: artifact writer does not tell the user to run /spec before review gate passes', () => {
+    const content = readFile('commands/discover/artifact-writer.md');
+
+    expect(content).not.toContain('Run /spec to continue.');
+    expect(content).toContain('Critic + Supervisor review');
+    expect(content).toContain('before presenting completion or `/spec`');
+  });
+
+  it('TEST-070-005b: artifact writer does not claim ownership of discover_review.json', () => {
+    const content = readFile('commands/discover/artifact-writer.md');
+
+    expect(content).not.toContain('`specs/features/feat-{featureSlug}/discover_review.json`\n');
+    expect(content).toContain('is **not** written by this artifact writer');
+    expect(content).toContain('created later by the mandatory independent Critic + Supervisor review gate');
+  });
+
   it('TEST-070-006: SKILL.md dispatch contracts reference all sub-skill files', () => {
     const content = readFile('commands/discover/SKILL.md');
     
@@ -612,5 +628,32 @@ describe('Context budget e2e tests (PR #60)', () => {
     const ac1 = req011.acceptance_criteria.find((c: any) => c.id === 'REQ-011-AC-1');
     expect(ac1).toBeDefined();
     expect(ac1.ears).toContain('< 200K chars');
+  });
+
+  it('TEST-070-011: discover skill makes Critic + Supervisor the mandatory next step after artifact writing', () => {
+    const content = readFile('commands/discover/SKILL.md');
+
+    expect(content).toContain('Discover is **not complete** after Layer 3 or artifact writing');
+    expect(content).toContain('Next: mandatory Critic + Supervisor dispatch');
+    expect(content).toContain('do NOT tell the user to run `/spec` yet');
+    expect(content).toContain('fresh independent Critic pass');
+  });
+
+  it('TEST-070-012: critic-supervisor contract forbids inline review and manual pass marking', () => {
+    const content = readFile('commands/discover/critic-supervisor.md');
+
+    expect(content).toContain('MUST NOT');
+    expect(content).toContain('inline the Critic review or Supervisor review');
+    expect(content).toContain('manually mark `passed: true`, `aligned: true`');
+    expect(content).toContain('discover_review.json.self_fix_log');
+    expect(content).toContain('MUST NOT treat self-fixed output as passed');
+  });
+
+  it('TEST-070-013: supervisor may run only after a fresh Critic pass', () => {
+    const content = readFile('commands/discover/critic-supervisor.md');
+
+    expect(content).toContain('After Critic passes:');
+    expect(content).toContain('MUST re-run Critic and wait for a fresh passing review before entering Supervisor');
+    expect(content).not.toContain('After Critic passes (or user resolves Critic findings):');
   });
 });


### PR DESCRIPTION
## Summary
- tighten the discover prompt contracts so artifact writing cannot bypass the independent Critic and Supervisor review gate
- require a fresh Critic pass after self-fixes or manual issue resolution before Supervisor or `/spec` can proceed
- add structure regression tests and progress tracking notes for issues #69, #70, #48, and #58

## What changed
- updated `commands/discover/SKILL.md` to make Critic + Supervisor the mandatory next step after artifact generation and to forbid presenting `/spec` early
- updated `commands/discover/critic-supervisor.md` to forbid inline/manual pass shortcuts, require `self_fix_log`, and require a fresh Critic pass before Supervisor after any manual resolution
- updated `commands/discover/artifact-writer.md` so it no longer claims ownership of `discover_review.json` and no longer tells the user to run `/spec`
- extended `src/skill-engine/__tests__/skill-structure.test.ts` with regression checks for the review-gate guarantees
- recorded the repair and follow-up notes in `docs/tracking/progress.md`

## Verification
- `pnpm test src/skill-engine/__tests__/skill-structure.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm test`

## Issues
- closes #69
- closes #70
- closes #48
- closes #58