### PR TITLE
fix: close lash phase guard gaps for issues 65 and 66

### DIFF
--- a/commands/lash-build.md
+++ b/commands/lash-build.md
@@ -60,7 +60,7 @@ Dispatch a sub-agent for the tracer bullet. Pass the tracer module list and an a
 
 Use the Agent tool:
 ```
-Agent(prompt="Follow the instructions in commands/lash-tracer.md. Tracer modules: <module_ids>. Platform: <platform>. Project root: <cwd>.")
+Agent(prompt="Follow the instructions in commands/lash-tracer.md. current_phase=planning. stage_guard=tracer_only. You are only responsible for the tracer bullet phase. Stop after you return the tracer result. Do not execute batch execution, final verification, or completion steps. Tracer modules: <module_ids>. Platform: <platform>. Project root: <cwd>.")
 ```
 
 Wait for the agent to complete. Read its result.
@@ -70,7 +70,8 @@ If tracer succeeds: proceed to Step 5.
 
 Update state:
 ```
-bash "lash state update tracer_completed --data '{}'
+bash "lash state update tracer_completed --data '{}'"
+
 ```
 
 ## Step 5: Parallel Batch Execution
@@ -81,7 +82,7 @@ Assign platforms to modules using round-robin across available platforms.
 
 Dispatch a sub-agent for the batch:
 ```
-Agent(prompt="Follow the instructions in commands/lash-batch.md. Batch <N>: modules <module_ids>. Platforms: <assignments>. Completed modules: <list>. Project root: <cwd>.")
+Agent(prompt="Follow the instructions in commands/lash-batch.md. current_phase=batch_execution. stage_guard=batch_execution_only. You are only responsible for the assigned batch execution phase. Stop after you return the batch result. Do not rerun tracer work, final verification, or completion steps. Batch <N>: modules <module_ids>. Platforms: <assignments>. Completed modules: <list>. Project root: <cwd>.")
 ```
 
 If batches are independent, you MAY dispatch multiple batch agents in parallel using the Agent tool's parallel execution capability. However, each batch must complete before the next dependent batch starts (respect the topological ordering from the plan).
@@ -95,7 +96,7 @@ bash "lash state update batch_completed --data '{\"batch_id\": <N>}'"
 
 Dispatch a sub-agent for verification:
 ```
-Agent(prompt="Follow the instructions in commands/lash-verify.md. Project root: <cwd>.")
+Agent(prompt="Follow the instructions in commands/lash-verify.md. current_phase=batch_execution. stage_guard=final_verification_only. You are only responsible for final verification. Stop after you return the verification result. Do not rerun tracer work, dispatch batch execution, or mark the build completed yourself. Project root: <cwd>.")
 ```
 
 The verify agent handles: full test suite, auto-acceptance, Build Critic, Supervisor.

--- a/commands/lash-build.md
+++ b/commands/lash-build.md
@@ -103,7 +103,7 @@ The verify agent handles: full test suite, auto-acceptance, Build Critic, Superv
 
 ## Step 7: Completion
 
-If verify succeeds:
+If verify succeeds and `specs/build-state.json` already records both `build_critic_passed` and `supervisor_passed`:
 ```
 bash "lash state update build_completed"
 ```

--- a/commands/lash-tracer/test-handler.md
+++ b/commands/lash-tracer/test-handler.md
@@ -38,7 +38,7 @@ Read the `level` from the JSON output. Use this as a hint, but make your own fin
 
 - **L2 (contract impact)**: behavior contradicts spec. STOP. Update state:
   ```
-  bash "lash state update build_paused --data '{\"pause_reason\": \"l2\", \"detail\": \"<description>\"}'"
+  bash "lash state update build_paused --data '{\"reason\": \"l2\", \"detail\": \"<description>\"}'"
   ```
   Present the user with product-level options: ACCEPT_DEGRADATION, CUT_FEATURE, MODIFY_SPEC, RETRY_DIFFERENT_APPROACH, BACKTRACK_DISCOVER.
 

--- a/commands/lash-verify/build-critic.md
+++ b/commands/lash-verify/build-critic.md
@@ -19,6 +19,12 @@ Then compare your results with the `acceptance_result` from `specs/build_report.
 - If they agree: alignment confirmed
 - If they DISAGREE: flag the divergence — this means the auto-acceptance has bias
 
+Mark the review as started before you generate outputs:
+
+```
+bash "lash state update build_critic_spawned --data '{}'"
+```
+
 Write `specs/build_review.json`:
 ```json
 {
@@ -31,12 +37,6 @@ Write `specs/build_review.json`:
   "recommendation": "pass|L2|L3",
   "detail": null
 }
-```
-
-Update build state before returning:
-
-```
-bash "lash state update build_critic_spawned --data '{}'"
 ```
 
 After completing the review:

--- a/commands/lash-verify/build-critic.md
+++ b/commands/lash-verify/build-critic.md
@@ -33,6 +33,24 @@ Write `specs/build_review.json`:
 }
 ```
 
-If recommendation is `pass`: return to `SKILL.md` and proceed to Step 4 (supervisor).
-If `L2`: pause, present product-level options to user.
-If `L3`: halt, present backtrack options.
+Update build state before returning:
+
+```
+bash "lash state update build_critic_spawned --data '{}'"
+```
+
+After completing the review:
+
+- If recommendation is `pass`, persist the successful review and then return to `SKILL.md` and proceed to Step 4 (supervisor):
+  ```
+  bash "lash state update build_critic_passed --data '{}'"
+  ```
+- If recommendation is `L2`, persist the failed review, then pause and present product-level options to user:
+  ```
+  bash "lash state update build_critic_failed --data '{\"detail\": \"<description>\"}'"
+  bash "lash state update build_paused --data '{\"reason\": \"critic\", \"detail\": \"<description>\"}'"
+  ```
+- If recommendation is `L3`, persist the failed review and halt with backtrack options:
+  ```
+  bash "lash state update build_critic_failed --data '{\"detail\": \"<description>\"}'"
+  ```

--- a/commands/lash-verify/build-critic.md
+++ b/commands/lash-verify/build-critic.md
@@ -53,4 +53,5 @@ After completing the review:
 - If recommendation is `L3`, persist the failed review and halt with backtrack options:
   ```
   bash "lash state update build_critic_failed --data '{\"detail\": \"<description>\"}'"
+  bash "lash state update build_paused --data '{\"reason\": \"critic\", \"detail\": \"<description>\"}'"
   ```

--- a/commands/lash-verify/supervisor.md
+++ b/commands/lash-verify/supervisor.md
@@ -17,6 +17,12 @@ These are the ANCHOR — the user's original intent.
 
 Read `specs/build_report.json` — this is the OUTPUT.
 
+Mark the supervisor review as started before you generate the final coherence assessment:
+
+```
+bash "lash state update supervisor_spawned --data '{}'"
+```
+
 Evaluate three dimensions:
 1. **Intent alignment**: Does the build output serve the stated direction? Or has it drifted?
 2. **Complexity growth**: Is the implementation proportional to requirements? Or over-engineered?
@@ -32,12 +38,6 @@ Write your assessment into `specs/build_report.json` in the `global_coherence_ch
     "detail": "explanation if any non-ideal"
   }
 }
-```
-
-Update build state before returning:
-
-```
-bash "lash state update supervisor_spawned --data '{}'"
 ```
 
 After completing the assessment:

--- a/commands/lash-verify/supervisor.md
+++ b/commands/lash-verify/supervisor.md
@@ -34,5 +34,20 @@ Write your assessment into `specs/build_report.json` in the `global_coherence_ch
 }
 ```
 
-If ALL three are ideal: build is complete. Update state.
-If ANY is non-ideal: pause, present diagnosis to user. Options: ACCEPT_AS_IS, BACKTRACK_SPEC, BACKTRACK_DISCOVER.
+Update build state before returning:
+
+```
+bash "lash state update supervisor_spawned --data '{}'"
+```
+
+After completing the assessment:
+
+- If ALL three are ideal, persist the successful review and return to `SKILL.md` so the parent orchestrator can mark build completion:
+  ```
+  bash "lash state update supervisor_passed --data '{}'"
+  ```
+- If ANY dimension is non-ideal, persist the failed review, then pause and present diagnosis to user. Options: ACCEPT_AS_IS, BACKTRACK_SPEC, BACKTRACK_DISCOVER.
+  ```
+  bash "lash state update supervisor_failed --data '{\"detail\": \"<description>\"}'"
+  bash "lash state update build_paused --data '{\"reason\": \"supervisor\", \"detail\": \"<description>\"}'"
+  ```

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -413,6 +413,8 @@
   - 补齐 `commands/lash-verify/build-critic.md` 与 `commands/lash-verify/supervisor.md` 的状态写回说明，使 `build_critic_*` / `supervisor_*` 事件与 `current_phase` 真正形成闭环
   - 修正 `commands/lash-tracer/test-handler.md` 的 L2 暂停字段名，使其与 `build-state` 识别的 `reason` 契约一致
   - 更新 `docs/zh-CN/USER_GUIDE.md` 中 build-state 事件数、`tracer_completed` 与 phase 前置条件说明，补齐用户侧文档
+  - 收紧 `build_completed` 的完成条件，要求最近一次 Build Critic / Supervisor verdict 都为 passed，避免 review 未通过也能完成构建
+  - 让 `build_critic_failed` / `supervisor_failed` 在未进入 pause 前先落到顶层 failed 状态，并把 verify spawn 事件前移到产物写入之前，补齐审计时序
 - 当前问题:
   - `lash-build` 的 `stage_guard` 目前仍属于 prompt 级软约束；若后续需要更强保证，可继续演进为结构化 runtime contract
 - 值得深入研究的问题:

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -419,3 +419,18 @@
   - `lash-build` 的 `stage_guard` 目前仍属于 prompt 级软约束；若后续需要更强保证，可继续演进为结构化 runtime contract
 - 值得深入研究的问题:
   - 是否应将 Lash 各阶段 dispatch 从“自由文本提示”继续收敛为统一的结构化上下文契约（phase/stage_guard/input/output），并由结构测试统一校验
+
+## Progress Snapshot: 2026-04-10 04:05
+- 触发方式: 跟进 PR #84 二轮 review，补齐 review pass 结果与 supervisor 进入门禁的最后缺口
+- 代码统计: 本次继续修改 `src/lash/build-state.ts`、回归测试、verify 提示契约与用户文档
+- 当前版本: V0.0.6 缺陷修复中
+- 本次工作:
+  - 为 `supervisor_spawned` 增加 runtime 硬门禁，要求最近一次 Build Critic 结果必须为 `build_critic_passed`，避免仅凭进入 `build_critic` phase 就可推进到 Supervisor
+  - 调整 `tests/build-state.test.ts` 与 `tests/cli-cleanup.test.ts` 的负向用例，使其对齐新的 runtime 语义，并补充 artifact 不应被误清理的断言
+  - 补充 `commands/lash-verify/build-critic.md` 的 L3 路径暂停写回，确保 human-blocking 路径不会停留在 `in_progress`
+  - 更新 `commands/lash-build.md`、`src/skill-engine/__tests__/skill-structure.test.ts` 与 `docs/zh-CN/USER_GUIDE.md`，同步 completion gate / spawn 顺序 / paused 契约
+  - 运行定向回归、全量测试、lint 与 build，验证当前修补未引入新增回归
+- 当前问题:
+  - `lash-build` 仍通过 prompt 合同驱动 verify orchestration；若后续引入结构化 runtime contract，可进一步减少文档与实现漂移风险
+- 值得深入研究的问题:
+  - 是否应在 `build-state.json` 中显式持久化“最近一次 review verdict”而不是完全依赖 `transition_log` 倒推 gate，以降低未来状态机复杂度

--- a/docs/tracking/progress.md
+++ b/docs/tracking/progress.md
@@ -396,3 +396,24 @@
   - GitHub 侧仍显示 `gh pr checks 80` 为 `no checks reported`；本轮验收依赖本地完整验证日志与子代理/Oracle 复核证据，而非远端 CI 记录
 - 值得深入研究的问题:
   - 是否需要把 review 子代理与本地验证结果自动沉淀为仓库内标准化验收记录，避免后续 ULTRAWORK/Oracle 验收时再次因“证据不集中”被卡住
+
+## Progress Snapshot: 2026-04-10 01:35
+- 触发方式: 修复 issue #65 / #66（lash phase 泄漏与 build-state phase 门禁）
+- 代码统计: 本次修改 `src/lash` 状态机、`commands/lash-build.md` 调度约束、回归测试与跟踪文档
+- 当前版本: V0.0.6 缺陷修复中
+- 本次计划:
+  - 为 `build-state` 补齐 `tracer_completed` 事件与最小 phase 前置条件校验
+  - 为 `lash-build` 子 agent dispatch 显式传递 `current_phase` / `stage_guard`，防止 tracer、batch、verify 串阶段
+  - 运行受影响测试、全量测试、lint 与 build，整理为可合并 PR
+- 本次工作:
+  - 在 `src/lash/types.ts` / `src/lash/build-state.ts` 中引入 `tracer_completed` 与 phase guard 语义，阻止从 `planning` 直接进入 batch / critic / completion
+  - 更新 `tests/build-state.test.ts` 与 `tests/cli-cleanup.test.ts`，补齐 phase-aware 回归覆盖与 CLI `state update tracer_completed` 入口验证
+  - 更新 `commands/lash-build.md`，为 tracer / batch / verify 子 agent dispatch 添加显式 `current_phase` 与 `stage_guard` 约束，并修正 tracer 状态更新命令示例的引号闭合
+  - 在 `src/skill-engine/__tests__/skill-structure.test.ts` 增补 lash-build dispatch guard 断言，避免后续回归
+  - 补齐 `commands/lash-verify/build-critic.md` 与 `commands/lash-verify/supervisor.md` 的状态写回说明，使 `build_critic_*` / `supervisor_*` 事件与 `current_phase` 真正形成闭环
+  - 修正 `commands/lash-tracer/test-handler.md` 的 L2 暂停字段名，使其与 `build-state` 识别的 `reason` 契约一致
+  - 更新 `docs/zh-CN/USER_GUIDE.md` 中 build-state 事件数、`tracer_completed` 与 phase 前置条件说明，补齐用户侧文档
+- 当前问题:
+  - `lash-build` 的 `stage_guard` 目前仍属于 prompt 级软约束；若后续需要更强保证，可继续演进为结构化 runtime contract
+- 值得深入研究的问题:
+  - 是否应将 Lash 各阶段 dispatch 从“自由文本提示”继续收敛为统一的结构化上下文契约（phase/stage_guard/input/output），并由结构测试统一校验

--- a/docs/zh-CN/USER_GUIDE.md
+++ b/docs/zh-CN/USER_GUIDE.md
@@ -1068,7 +1068,7 @@ Lash 的构建状态持久化到 `specs/build-state.json`。
 
 - 只有 `tracer_completed` 能把 phase 从 `planning` 推进到 `batch_execution`
 - 只有在 `batch_execution` 中才允许触发 `batch_completed` 与 `build_critic_spawned`
-- 只有在 `build_critic` 中才允许触发 `build_critic_passed` / `build_critic_failed` / `supervisor_spawned`
+- 只有在 `build_critic` 中才允许触发 `build_critic_passed` / `build_critic_failed` / `supervisor_spawned`，且 `supervisor_spawned` 还要求最近一次 Build Critic verdict 为 `build_critic_passed`
 - 只有在 `supervisor` 中才允许触发 `supervisor_passed` / `supervisor_failed`
 - `build_completed` 只能在 `supervisor` phase 中触发，且最近一次 Build Critic / Supervisor verdict 必须分别为 `build_critic_passed` 与 `supervisor_passed`
 - `build_critic_failed` 与 `supervisor_failed` 会先把顶层构建状态记为 `failed`；若后续要等待人工决策，必须再发送 `build_paused`

--- a/docs/zh-CN/USER_GUIDE.md
+++ b/docs/zh-CN/USER_GUIDE.md
@@ -1027,7 +1027,7 @@ Lash 的构建状态持久化到 `specs/build-state.json`。
 
 **原子写入保证：** 使用"临时文件 + `fs.renameSync`"模式，防止进程崩溃导致状态文件损坏。
 
-**21 种状态转换事件：**
+**22 种状态转换事件：**
 
 | 事件 | 含义 |
 |------|------|
@@ -1040,6 +1040,7 @@ Lash 的构建状态持久化到 `specs/build-state.json`。
 | `module_critic_spawned` | 模块 Critic 已启动 |
 | `module_critic_passed` | 模块 Critic 通过 |
 | `module_critic_failed` | 模块 Critic 失败 |
+| `tracer_completed` | Tracer 阶段完成，允许进入批次执行 |
 | `batch_completed` | 批次完成 |
 | `merge_completed` | 合并完成 |
 | `merge_conflict` | 合并冲突 |
@@ -1052,6 +1053,24 @@ Lash 的构建状态持久化到 `specs/build-state.json`。
 | `build_paused` | 构建暂停 |
 | `build_completed` | 构建完成 |
 | `build_backtracked` | 构建回溯 |
+
+**5 个运行时 phase：**
+
+| phase | 含义 |
+|------|------|
+| `planning` | Tracer 前的初始阶段 |
+| `batch_execution` | Tracer 完成后，执行并合并批次模块 |
+| `build_critic` | Final verification 中的 Build Critic 审查 |
+| `supervisor` | Final verification 中的 Supervisor 审查 |
+| `acceptance` | 构建已完成，进入最终验收状态 |
+
+**phase 前置条件：**
+
+- 只有 `tracer_completed` 能把 phase 从 `planning` 推进到 `batch_execution`
+- 只有在 `batch_execution` 中才允许触发 `batch_completed` 与 `build_critic_spawned`
+- 只有在 `build_critic` 中才允许触发 `build_critic_passed` / `build_critic_failed` / `supervisor_spawned`
+- 只有在 `supervisor` 中才允许触发 `supervisor_passed` / `supervisor_failed`
+- `build_completed` 只能在 `supervisor` phase 中触发，确保 Build Critic 与 Supervisor 都已留下状态痕迹后才进入 `acceptance`
 
 **7 种构建状态：**
 

--- a/docs/zh-CN/USER_GUIDE.md
+++ b/docs/zh-CN/USER_GUIDE.md
@@ -1070,7 +1070,8 @@ Lash 的构建状态持久化到 `specs/build-state.json`。
 - 只有在 `batch_execution` 中才允许触发 `batch_completed` 与 `build_critic_spawned`
 - 只有在 `build_critic` 中才允许触发 `build_critic_passed` / `build_critic_failed` / `supervisor_spawned`
 - 只有在 `supervisor` 中才允许触发 `supervisor_passed` / `supervisor_failed`
-- `build_completed` 只能在 `supervisor` phase 中触发，确保 Build Critic 与 Supervisor 都已留下状态痕迹后才进入 `acceptance`
+- `build_completed` 只能在 `supervisor` phase 中触发，且最近一次 Build Critic / Supervisor verdict 必须分别为 `build_critic_passed` 与 `supervisor_passed`
+- `build_critic_failed` 与 `supervisor_failed` 会先把顶层构建状态记为 `failed`；若后续要等待人工决策，必须再发送 `build_paused`
 
 **7 种构建状态：**
 

--- a/src/lash/build-state.ts
+++ b/src/lash/build-state.ts
@@ -123,23 +123,28 @@ function getLatestTransitionEvent(
   return null;
 }
 
+function assertLatestReviewPassed(
+  state: BuildState,
+  stageName: 'build_critic' | 'supervisor',
+  requiredEvent: BuildEvent,
+  blockedEvent: BuildEvent,
+): void {
+  const latestEvent = getLatestTransitionEvent(state.transition_log, stageName === 'build_critic'
+    ? ['build_critic_passed', 'build_critic_failed']
+    : ['supervisor_passed', 'supervisor_failed']);
+
+  if (latestEvent === requiredEvent) {
+    return;
+  }
+
+  throw new Error(
+    `invalid_transition: ${blockedEvent} requires latest ${stageName} result to be ${requiredEvent}`,
+  );
+}
+
 function assertBuildCompletionReady(state: BuildState): void {
-  const latestBuildCriticEvent = getLatestTransitionEvent(state.transition_log, [
-    'build_critic_passed',
-    'build_critic_failed',
-  ]);
-  const latestSupervisorEvent = getLatestTransitionEvent(state.transition_log, [
-    'supervisor_passed',
-    'supervisor_failed',
-  ]);
-
-  if (latestBuildCriticEvent !== 'build_critic_passed') {
-    throw new Error('invalid_transition: build_completed requires build_critic_passed');
-  }
-
-  if (latestSupervisorEvent !== 'supervisor_passed') {
-    throw new Error('invalid_transition: build_completed requires supervisor_passed');
-  }
+  assertLatestReviewPassed(state, 'build_critic', 'build_critic_passed', 'build_completed');
+  assertLatestReviewPassed(state, 'supervisor', 'supervisor_passed', 'build_completed');
 }
 
 function workerPendingAction(workerStatus: string): string {
@@ -267,6 +272,9 @@ export function recordTransition(
   const currentPhase = newState.current_phase;
 
   assertPhaseAllowed(currentPhase, event as BuildEvent);
+  if (event === 'supervisor_spawned') {
+    assertLatestReviewPassed(newState, 'build_critic', 'build_critic_passed', 'supervisor_spawned');
+  }
   if (event === 'build_completed') {
     assertBuildCompletionReady(newState);
   }

--- a/src/lash/build-state.ts
+++ b/src/lash/build-state.ts
@@ -109,6 +109,39 @@ function assertPhaseAllowed(phase: BuildPhase, event: BuildEvent): void {
   );
 }
 
+function getLatestTransitionEvent(
+  transitionLog: readonly TransitionLogEntry[],
+  events: readonly BuildEvent[],
+): BuildEvent | null {
+  for (let index = transitionLog.length - 1; index >= 0; index -= 1) {
+    const candidate = transitionLog[index]?.event;
+    if (candidate !== undefined && events.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function assertBuildCompletionReady(state: BuildState): void {
+  const latestBuildCriticEvent = getLatestTransitionEvent(state.transition_log, [
+    'build_critic_passed',
+    'build_critic_failed',
+  ]);
+  const latestSupervisorEvent = getLatestTransitionEvent(state.transition_log, [
+    'supervisor_passed',
+    'supervisor_failed',
+  ]);
+
+  if (latestBuildCriticEvent !== 'build_critic_passed') {
+    throw new Error('invalid_transition: build_completed requires build_critic_passed');
+  }
+
+  if (latestSupervisorEvent !== 'supervisor_passed') {
+    throw new Error('invalid_transition: build_completed requires supervisor_passed');
+  }
+}
+
 function workerPendingAction(workerStatus: string): string {
   const mapping: Record<string, string> = {
     pending: 'spawn_worker',
@@ -234,6 +267,9 @@ export function recordTransition(
   const currentPhase = newState.current_phase;
 
   assertPhaseAllowed(currentPhase, event as BuildEvent);
+  if (event === 'build_completed') {
+    assertBuildCompletionReady(newState);
+  }
 
   // --- Apply state-level transitions ---
   if (event === 'tracer_completed') {
@@ -243,6 +279,9 @@ export function recordTransition(
     toStatus = 'completed';
     newState.status = 'completed';
     newState.current_phase = 'acceptance';
+  } else if (event === 'build_critic_failed' || event === 'supervisor_failed') {
+    toStatus = 'failed';
+    newState.status = 'failed';
   } else if (event === 'build_backtracked') {
     toStatus = 'backtracked';
     newState.status = 'backtracked' as BuildStatus;

--- a/src/lash/build-state.ts
+++ b/src/lash/build-state.ts
@@ -3,7 +3,7 @@
  * Mirrors Python lash/build_state.py exactly — MOD-008.
  *
  * Atomic state file read/write (write-to-temp + fs.renameSync).
- * Supports all 21 transition events. Crash recovery / resume logic.
+ * Supports all 22 transition events. Crash recovery / resume logic.
  */
 import { existsSync, readFileSync, renameSync, writeFileSync, copyFileSync } from 'node:fs';
 import { dirname, resolve, basename } from 'node:path';
@@ -11,6 +11,7 @@ import type {
   BuildState,
   BuildEvent,
   BuildStatus,
+  BuildPhase,
   WorkerStatus,
   BatchEntry,
   WorkerEntry,
@@ -34,6 +35,7 @@ export const VALID_EVENTS: ReadonlySet<BuildEvent> = new Set<BuildEvent>([
   'module_critic_spawned',
   'module_critic_passed',
   'module_critic_failed',
+  'tracer_completed',
   'batch_completed',
   'merge_completed',
   'merge_conflict',
@@ -76,12 +78,35 @@ const WORKER_EVENT_STATUS: Readonly<Partial<Record<BuildEvent, WorkerStatus>>> =
   merge_conflict: 'merge_conflict',
 };
 
+const PHASE_EVENT_GUARDS: Readonly<Partial<Record<BuildEvent, readonly BuildPhase[]>>> = {
+  tracer_completed: ['planning'],
+  batch_completed: ['batch_execution'],
+  build_critic_spawned: ['batch_execution'],
+  build_critic_passed: ['build_critic'],
+  build_critic_failed: ['build_critic'],
+  supervisor_spawned: ['build_critic'],
+  supervisor_passed: ['supervisor'],
+  supervisor_failed: ['supervisor'],
+  build_completed: ['supervisor'],
+};
+
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function assertPhaseAllowed(phase: BuildPhase, event: BuildEvent): void {
+  const allowedPhases = PHASE_EVENT_GUARDS[event];
+  if (!allowedPhases || allowedPhases.includes(phase)) {
+    return;
+  }
+
+  throw new Error(
+    `invalid_transition: event ${JSON.stringify(event)} is not allowed during phase ${JSON.stringify(phase)}`,
+  );
 }
 
 function workerPendingAction(workerStatus: string): string {
@@ -192,6 +217,10 @@ export function recordTransition(
   // Shallow copy to avoid mutating input
   const newState: BuildState = {
     ...state,
+    tracer: {
+      ...state.tracer,
+      module_statuses: { ...(state.tracer?.module_statuses ?? {}) },
+    },
     transition_log: [...(state.transition_log ?? [])],
     batches: (state.batches ?? []).map((b) => ({ ...b })),
   };
@@ -202,9 +231,15 @@ export function recordTransition(
 
   const fromStatus = newState.status as string;
   let toStatus = fromStatus;
+  const currentPhase = newState.current_phase;
+
+  assertPhaseAllowed(currentPhase, event as BuildEvent);
 
   // --- Apply state-level transitions ---
-  if (event === 'build_completed') {
+  if (event === 'tracer_completed') {
+    newState.tracer.status = 'completed';
+    newState.current_phase = 'batch_execution';
+  } else if (event === 'build_completed') {
     toStatus = 'completed';
     newState.status = 'completed';
     newState.current_phase = 'acceptance';

--- a/src/lash/types.ts
+++ b/src/lash/types.ts
@@ -23,10 +23,10 @@ export interface LashConfig {
 }
 
 // ---------------------------------------------------------------------------
-// build_state.py — 21 event types + state structures
+// build_state.py — 22 event types + state structures
 // ---------------------------------------------------------------------------
 
-/** All 21 valid build-state transition events. */
+/** All 22 valid build-state transition events. */
 export type BuildEvent =
   | 'worker_spawned'
   | 'worker_completed'
@@ -37,6 +37,7 @@ export type BuildEvent =
   | 'module_critic_spawned'
   | 'module_critic_passed'
   | 'module_critic_failed'
+  | 'tracer_completed'
   | 'batch_completed'
   | 'merge_completed'
   | 'merge_conflict'
@@ -59,6 +60,14 @@ export type BuildStatus =
   | 'paused_l2'
   | 'paused_critic'
   | 'paused_supervisor';
+
+/** Runtime build phases tracked by build-state.json. */
+export type BuildPhase =
+  | 'planning'
+  | 'batch_execution'
+  | 'build_critic'
+  | 'supervisor'
+  | 'acceptance';
 
 /** Worker-level status values (set by _WORKER_EVENT_STATUS mapping). */
 export type WorkerStatus =
@@ -116,7 +125,7 @@ export interface BuildState {
   spec_hash: string;
   started_at: string;
   updated_at: string;
-  current_phase: string;
+  current_phase: BuildPhase;
   tracer: TracerStateEntry;
   batches: BatchEntry[];
   transition_log: TransitionLogEntry[];
@@ -131,7 +140,7 @@ export interface SessionRecoveryEntry {
 
 /** Return type of get_resume_point(). */
 export interface ResumePoint {
-  phase: string;
+  phase: BuildPhase;
   batch_id: string | null;
   module_id: string | null;
   pending_action: string;
@@ -388,4 +397,3 @@ export interface CancelResult {
 export interface ResumeOutput {
   sent: boolean;
 }
-

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -267,6 +267,18 @@ describe('Sub-skill references', () => {
     expect(supervisor).toContain('supervisor_failed');
   });
 
+  it('TEST-067: lash-verify spawn transitions are documented before result files are written', () => {
+    const buildCritic = readFile('commands/lash-verify/build-critic.md');
+    const supervisor = readFile('commands/lash-verify/supervisor.md');
+
+    expect(buildCritic.indexOf('build_critic_spawned')).toBeLessThan(
+      buildCritic.indexOf('Write `specs/build_review.json`:'),
+    );
+    expect(supervisor.indexOf('supervisor_spawned')).toBeLessThan(
+      supervisor.indexOf('Write your assessment into `specs/build_report.json`'),
+    );
+  });
+
   it('TEST-066: lash-tracer L2 pause uses reason field expected by build-state', () => {
     const content = readFile('commands/lash-tracer/test-handler.md');
     expect(content).toContain('\\"reason\\": \\"l2\\"');

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -262,9 +262,11 @@ describe('Sub-skill references', () => {
     expect(buildCritic).toContain('build_critic_spawned');
     expect(buildCritic).toContain('build_critic_passed');
     expect(buildCritic).toContain('build_critic_failed');
+    expect(buildCritic).toContain('build_paused');
     expect(supervisor).toContain('supervisor_spawned');
     expect(supervisor).toContain('supervisor_passed');
     expect(supervisor).toContain('supervisor_failed');
+    expect(supervisor).toContain('build_paused');
   });
 
   it('TEST-067: lash-verify spawn transitions are documented before result files are written', () => {

--- a/src/skill-engine/__tests__/skill-structure.test.ts
+++ b/src/skill-engine/__tests__/skill-structure.test.ts
@@ -255,6 +255,25 @@ describe('Sub-skill references', () => {
     expect(count).toBeGreaterThanOrEqual(2);
   });
 
+  it('TEST-067: lash-verify sub-skills persist build_critic and supervisor state transitions', () => {
+    const buildCritic = readFile('commands/lash-verify/build-critic.md');
+    const supervisor = readFile('commands/lash-verify/supervisor.md');
+
+    expect(buildCritic).toContain('build_critic_spawned');
+    expect(buildCritic).toContain('build_critic_passed');
+    expect(buildCritic).toContain('build_critic_failed');
+    expect(supervisor).toContain('supervisor_spawned');
+    expect(supervisor).toContain('supervisor_passed');
+    expect(supervisor).toContain('supervisor_failed');
+  });
+
+  it('TEST-066: lash-tracer L2 pause uses reason field expected by build-state', () => {
+    const content = readFile('commands/lash-tracer/test-handler.md');
+    expect(content).toContain('\\"reason\\": \\"l2\\"');
+    expect(content).toContain('build_paused --data');
+    expect(content).not.toContain('pause_reason');
+  });
+
   // --- lash integration ---
 
   it('TEST-068: lash-build.md or lash-orchestrator.md references both lash-tracer and lash-verify', () => {
@@ -267,6 +286,15 @@ describe('Sub-skill references', () => {
 
     expect(combined).toMatch(/lash-tracer/);
     expect(combined).toMatch(/lash-verify/);
+  });
+
+  it('TEST-069: lash-build.md passes explicit phase and stage guards to child agent dispatches', () => {
+    const content = readFile('commands/lash-build.md');
+    expect(content).toContain('current_phase=planning');
+    expect(content).toContain('stage_guard=tracer_only');
+    expect(content).toContain('current_phase=batch_execution');
+    expect(content).toContain('stage_guard=batch_execution_only');
+    expect(content).toContain('stage_guard=final_verification_only');
   });
 });
 

--- a/tests/build-state.test.ts
+++ b/tests/build-state.test.ts
@@ -80,6 +80,19 @@ function makeValidTransitionInput(event: BuildEvent): {
   }
 }
 
+function prepareStateForEvent(baseState: BuildState, event: BuildEvent): BuildState {
+  if (event !== 'build_completed') {
+    return baseState;
+  }
+
+  let prepared = recordTransition(baseState, 'tracer_completed', {});
+  prepared = recordTransition(prepared, 'build_critic_spawned', {});
+  prepared = recordTransition(prepared, 'build_critic_passed', {});
+  prepared = recordTransition(prepared, 'supervisor_spawned', {});
+  prepared = recordTransition(prepared, 'supervisor_passed', {});
+  return prepared;
+}
+
 function makeWorkerState(moduleId = 'MOD-001') {
   return {
     module_id: moduleId,
@@ -257,19 +270,27 @@ describe('recordTransition', () => {
   });
 
   it('TEST-094: build_completed updates state status', () => {
-    state.current_phase = 'supervisor';
-    const updated = recordTransition(state, 'build_completed', {});
+    let readyState = recordTransition(state, 'tracer_completed', {});
+    readyState = recordTransition(readyState, 'build_critic_spawned', {});
+    readyState = recordTransition(readyState, 'build_critic_passed', {});
+    readyState = recordTransition(readyState, 'supervisor_spawned', {});
+    readyState = recordTransition(readyState, 'supervisor_passed', {});
+
+    const updated = recordTransition(readyState, 'build_completed', {});
     expect(updated.status).toBe('completed');
-    expect(updated.transition_log).toHaveLength(1);
-    expect(updated.transition_log[0].event).toBe('build_completed');
+    expect(updated.transition_log).toHaveLength(6);
+    expect(updated.transition_log[5].event).toBe('build_completed');
   });
 
   it('TEST-095: all 22 events are recognized when phase prerequisites are satisfied', () => {
     for (const event of VALID_EVENTS) {
-      const s = makeBaseState();
+      let s = makeBaseState();
       s.batches = [makeBatchState()];
       const { phase, data } = makeValidTransitionInput(event);
-      s.current_phase = phase;
+      s = prepareStateForEvent(s, event);
+      if (event !== 'build_completed') {
+        s.current_phase = phase;
+      }
       expect(() => recordTransition(s, event, data)).not.toThrow();
     }
   });
@@ -296,12 +317,35 @@ describe('recordTransition', () => {
     updated = recordTransition(updated, 'build_critic_spawned', {});
     expect(updated.current_phase).toBe('build_critic');
 
+    updated = recordTransition(updated, 'build_critic_passed', {});
+
     updated = recordTransition(updated, 'supervisor_spawned', {});
     expect(updated.current_phase).toBe('supervisor');
+
+    updated = recordTransition(updated, 'supervisor_passed', {});
 
     updated = recordTransition(updated, 'build_completed', {});
     expect(updated.current_phase).toBe('acceptance');
     expect(updated.status).toBe('completed');
+  });
+
+  it('TEST-095: build_completed requires passing critic and supervisor verdicts', () => {
+    let missingCriticPass = recordTransition(state, 'tracer_completed', {});
+    missingCriticPass = recordTransition(missingCriticPass, 'build_critic_spawned', {});
+    missingCriticPass = recordTransition(missingCriticPass, 'supervisor_spawned', {});
+
+    expect(() => recordTransition(missingCriticPass, 'build_completed', {})).toThrow(
+      'build_critic_passed',
+    );
+
+    let missingSupervisorPass = recordTransition(state, 'tracer_completed', {});
+    missingSupervisorPass = recordTransition(missingSupervisorPass, 'build_critic_spawned', {});
+    missingSupervisorPass = recordTransition(missingSupervisorPass, 'build_critic_passed', {});
+    missingSupervisorPass = recordTransition(missingSupervisorPass, 'supervisor_spawned', {});
+
+    expect(() => recordTransition(missingSupervisorPass, 'build_completed', {})).toThrow(
+      'supervisor_passed',
+    );
   });
 
   it('TEST-095: supervisor_spawned only advances from build_critic phase', () => {
@@ -323,9 +367,11 @@ describe('recordTransition', () => {
     s = recordTransition(s, 'test_passed', { module_id: 'MOD-001', batch_id: 'BATCH-001' });
     s = recordTransition(s, 'tracer_completed', {});
     s = recordTransition(s, 'build_critic_spawned', {});
+    s = recordTransition(s, 'build_critic_passed', {});
     s = recordTransition(s, 'supervisor_spawned', {});
+    s = recordTransition(s, 'supervisor_passed', {});
     s = recordTransition(s, 'build_completed', {});
-    expect(s.transition_log).toHaveLength(6);
+    expect(s.transition_log).toHaveLength(8);
   });
 
   it('transition log entry has valid timestamp', () => {
@@ -352,9 +398,21 @@ describe('recordTransition', () => {
   it('build_paused with reason=l2 sets paused_l2 status', () => {
     const s = makeBaseState();
     const updated = recordTransition(s, 'build_paused', { reason: 'l2' });
-    expect(['paused_l2', 'paused_critic', 'paused_supervisor', 'in_progress']).toContain(
-      updated.status,
-    );
+    expect(updated.status).toBe('paused_l2');
+  });
+
+  it('build_critic_failed marks the build as failed until a pause event overrides it', () => {
+    const s = makeBaseState();
+    s.current_phase = 'build_critic';
+    const updated = recordTransition(s, 'build_critic_failed', { detail: 'review failed' });
+    expect(updated.status).toBe('failed');
+  });
+
+  it('supervisor_failed marks the build as failed until a pause event overrides it', () => {
+    const s = makeBaseState();
+    s.current_phase = 'supervisor';
+    const updated = recordTransition(s, 'supervisor_failed', { detail: 'review failed' });
+    expect(updated.status).toBe('failed');
   });
 
   it('build_backtracked sets backtracked status', () => {

--- a/tests/build-state.test.ts
+++ b/tests/build-state.test.ts
@@ -14,7 +14,7 @@ import {
   getResumePoint,
   archiveState,
 } from '../src/lash/build-state.js';
-import type { BuildState, BuildEvent } from '../src/lash/types.js';
+import type { BuildState, BuildEvent, BuildPhase } from '../src/lash/types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers (mirror Python _make_* helpers)
@@ -30,6 +30,7 @@ const VALID_EVENTS: BuildEvent[] = [
   'module_critic_spawned',
   'module_critic_passed',
   'module_critic_failed',
+  'tracer_completed',
   'batch_completed',
   'merge_completed',
   'merge_conflict',
@@ -46,6 +47,37 @@ const VALID_EVENTS: BuildEvent[] = [
 
 function makeBaseState(specHash = 'abc123'): BuildState {
   return createInitialState(specHash);
+}
+
+function makeValidTransitionInput(event: BuildEvent): {
+  phase: BuildPhase;
+  data: Record<string, unknown>;
+} {
+  switch (event) {
+    case 'tracer_completed':
+      return { phase: 'planning', data: {} };
+    case 'batch_completed':
+      return { phase: 'batch_execution', data: { batch_id: 'BATCH-001' } };
+    case 'build_critic_spawned':
+      return { phase: 'batch_execution', data: {} };
+    case 'build_critic_passed':
+    case 'build_critic_failed':
+    case 'supervisor_spawned':
+      return { phase: 'build_critic', data: {} };
+    case 'supervisor_passed':
+    case 'supervisor_failed':
+    case 'build_completed':
+      return { phase: 'supervisor', data: {} };
+    case 'build_paused':
+      return { phase: 'planning', data: { reason: 'l2' } };
+    case 'build_backtracked':
+      return { phase: 'planning', data: {} };
+    default:
+      return {
+        phase: 'planning',
+        data: { module_id: 'MOD-001', batch_id: 'BATCH-001' },
+      };
+  }
 }
 
 function makeWorkerState(moduleId = 'MOD-001') {
@@ -225,20 +257,57 @@ describe('recordTransition', () => {
   });
 
   it('TEST-094: build_completed updates state status', () => {
+    state.current_phase = 'supervisor';
     const updated = recordTransition(state, 'build_completed', {});
     expect(updated.status).toBe('completed');
     expect(updated.transition_log).toHaveLength(1);
     expect(updated.transition_log[0].event).toBe('build_completed');
   });
 
-  it('TEST-095: all 21 events are recognized', () => {
+  it('TEST-095: all 22 events are recognized when phase prerequisites are satisfied', () => {
     for (const event of VALID_EVENTS) {
       const s = makeBaseState();
       s.batches = [makeBatchState()];
-      expect(() =>
-        recordTransition(s, event, { module_id: 'MOD-001', batch_id: 'BATCH-001' }),
-      ).not.toThrow();
+      const { phase, data } = makeValidTransitionInput(event);
+      s.current_phase = phase;
+      expect(() => recordTransition(s, event, data)).not.toThrow();
     }
+  });
+
+  it('TEST-095: tracer_completed advances current phase to batch_execution', () => {
+    const updated = recordTransition(state, 'tracer_completed', {});
+    expect(updated.current_phase).toBe('batch_execution');
+    expect(updated.tracer.status).toBe('completed');
+    expect(updated.transition_log[0].event).toBe('tracer_completed');
+  });
+
+  it('TEST-095: guarded phase transitions reject invalid phase jumps', () => {
+    expect(() => recordTransition(state, 'batch_completed', { batch_id: 'BATCH-001' })).toThrow(
+      'invalid_transition',
+    );
+    expect(() => recordTransition(state, 'build_critic_spawned', {})).toThrow(
+      'invalid_transition',
+    );
+    expect(() => recordTransition(state, 'build_completed', {})).toThrow('invalid_transition');
+  });
+
+  it('TEST-095: full verification chain must pass through critic and supervisor before completion', () => {
+    let updated = recordTransition(state, 'tracer_completed', {});
+    updated = recordTransition(updated, 'build_critic_spawned', {});
+    expect(updated.current_phase).toBe('build_critic');
+
+    updated = recordTransition(updated, 'supervisor_spawned', {});
+    expect(updated.current_phase).toBe('supervisor');
+
+    updated = recordTransition(updated, 'build_completed', {});
+    expect(updated.current_phase).toBe('acceptance');
+    expect(updated.status).toBe('completed');
+  });
+
+  it('TEST-095: supervisor_spawned only advances from build_critic phase', () => {
+    state.current_phase = 'build_critic';
+    const updated = recordTransition(state, 'supervisor_spawned', {});
+    expect(updated.current_phase).toBe('supervisor');
   });
 
   it('TEST-103: invalid event throws with invalid_transition', () => {
@@ -252,8 +321,11 @@ describe('recordTransition', () => {
     s.batches = [makeBatchState()];
     s = recordTransition(s, 'worker_spawned', { module_id: 'MOD-001', batch_id: 'BATCH-001' });
     s = recordTransition(s, 'test_passed', { module_id: 'MOD-001', batch_id: 'BATCH-001' });
+    s = recordTransition(s, 'tracer_completed', {});
+    s = recordTransition(s, 'build_critic_spawned', {});
+    s = recordTransition(s, 'supervisor_spawned', {});
     s = recordTransition(s, 'build_completed', {});
-    expect(s.transition_log).toHaveLength(3);
+    expect(s.transition_log).toHaveLength(6);
   });
 
   it('transition log entry has valid timestamp', () => {
@@ -324,6 +396,7 @@ describe('recordTransition', () => {
   it('batch_completed updates batch status to completed', () => {
     const s = makeBaseState();
     s.batches = [makeBatchState()];
+    s.current_phase = 'batch_execution';
     const updated = recordTransition(s, 'batch_completed', { batch_id: 'BATCH-001' });
     expect(updated.batches[0].status).toBe('completed');
   });
@@ -357,11 +430,11 @@ describe('getResumePoint', () => {
   it('TEST-096: resume from in_progress', () => {
     const state = makeBaseState();
     state.status = 'in_progress';
-    state.current_phase = 'implementing';
+    state.current_phase = 'batch_execution';
     state.batches = [makeBatchState()];
 
     const resume = getResumePoint(state);
-    expect(resume.phase).toBe('implementing');
+    expect(resume.phase).toBe('batch_execution');
     expect('batch_id' in resume).toBe(true);
     expect('module_id' in resume).toBe(true);
     expect('pending_action' in resume).toBe(true);
@@ -372,11 +445,11 @@ describe('getResumePoint', () => {
   it('TEST-097: resume from paused_l2', () => {
     const state = makeBaseState();
     state.status = 'paused_l2';
-    state.current_phase = 'testing';
+    state.current_phase = 'supervisor';
     state.batches = [makeBatchState()];
 
     const resume = getResumePoint(state);
-    expect(resume.phase).toBe('testing');
+    expect(resume.phase).toBe('supervisor');
     expect('pending_action' in resume).toBe(true);
   });
 

--- a/tests/build-state.test.ts
+++ b/tests/build-state.test.ts
@@ -81,16 +81,23 @@ function makeValidTransitionInput(event: BuildEvent): {
 }
 
 function prepareStateForEvent(baseState: BuildState, event: BuildEvent): BuildState {
-  if (event !== 'build_completed') {
-    return baseState;
+  if (event === 'build_completed') {
+    let prepared = recordTransition(baseState, 'tracer_completed', {});
+    prepared = recordTransition(prepared, 'build_critic_spawned', {});
+    prepared = recordTransition(prepared, 'build_critic_passed', {});
+    prepared = recordTransition(prepared, 'supervisor_spawned', {});
+    prepared = recordTransition(prepared, 'supervisor_passed', {});
+    return prepared;
   }
 
-  let prepared = recordTransition(baseState, 'tracer_completed', {});
-  prepared = recordTransition(prepared, 'build_critic_spawned', {});
-  prepared = recordTransition(prepared, 'build_critic_passed', {});
-  prepared = recordTransition(prepared, 'supervisor_spawned', {});
-  prepared = recordTransition(prepared, 'supervisor_passed', {});
-  return prepared;
+  if (event === 'supervisor_spawned') {
+    let prepared = recordTransition(baseState, 'tracer_completed', {});
+    prepared = recordTransition(prepared, 'build_critic_spawned', {});
+    prepared = recordTransition(prepared, 'build_critic_passed', {});
+    return prepared;
+  }
+
+  return baseState;
 }
 
 function makeWorkerState(moduleId = 'MOD-001') {
@@ -330,9 +337,10 @@ describe('recordTransition', () => {
   });
 
   it('TEST-095: build_completed requires passing critic and supervisor verdicts', () => {
-    let missingCriticPass = recordTransition(state, 'tracer_completed', {});
-    missingCriticPass = recordTransition(missingCriticPass, 'build_critic_spawned', {});
-    missingCriticPass = recordTransition(missingCriticPass, 'supervisor_spawned', {});
+    const missingCriticPass = {
+      ...state,
+      current_phase: 'supervisor' as const,
+    };
 
     expect(() => recordTransition(missingCriticPass, 'build_completed', {})).toThrow(
       'build_critic_passed',
@@ -348,9 +356,14 @@ describe('recordTransition', () => {
     );
   });
 
-  it('TEST-095: supervisor_spawned only advances from build_critic phase', () => {
+  it('TEST-095: supervisor_spawned only advances after a passed build_critic result', () => {
     state.current_phase = 'build_critic';
-    const updated = recordTransition(state, 'supervisor_spawned', {});
+    expect(() => recordTransition(state, 'supervisor_spawned', {})).toThrow(
+      'build_critic_passed',
+    );
+
+    const reviewed = recordTransition(state, 'build_critic_passed', {});
+    const updated = recordTransition(reviewed, 'supervisor_spawned', {});
     expect(updated.current_phase).toBe('supervisor');
   });
 

--- a/tests/cli-cleanup.test.ts
+++ b/tests/cli-cleanup.test.ts
@@ -202,10 +202,20 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
     );
     expect(criticResult.returncode).toBe(0);
 
+    const criticPassedResult = runLashInDir(
+      tmpDir, 'state', 'update', 'build_critic_passed', '--state-path', statePath, '--data', '{}',
+    );
+    expect(criticPassedResult.returncode).toBe(0);
+
     const supervisorResult = runLashInDir(
       tmpDir, 'state', 'update', 'supervisor_spawned', '--state-path', statePath, '--data', '{}',
     );
     expect(supervisorResult.returncode).toBe(0);
+
+    const supervisorPassedResult = runLashInDir(
+      tmpDir, 'state', 'update', 'supervisor_passed', '--state-path', statePath, '--data', '{}',
+    );
+    expect(supervisorPassedResult.returncode).toBe(0);
 
     // Trigger build_completed
     const result = runLashInDir(
@@ -258,5 +268,30 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
     const stateOutput = JSON.parse(result.stdout);
     expect(stateOutput.current_phase).toBe('batch_execution');
     expect(stateOutput.tracer.status).toBe('completed');
+  });
+
+  it('rejects build_completed until critic and supervisor pass events exist', () => {
+    const statePath = join(tmpDir, 'specs', 'build-state.json');
+    makeSpecsDir(tmpDir);
+
+    expect(runLashInDir(
+      tmpDir, 'state', 'create', '--spec-hash', 'abc123', '--state-path', statePath,
+    ).returncode).toBe(0);
+    expect(runLashInDir(
+      tmpDir, 'state', 'update', 'tracer_completed', '--state-path', statePath, '--data', '{}',
+    ).returncode).toBe(0);
+    expect(runLashInDir(
+      tmpDir, 'state', 'update', 'build_critic_spawned', '--state-path', statePath, '--data', '{}',
+    ).returncode).toBe(0);
+    expect(runLashInDir(
+      tmpDir, 'state', 'update', 'supervisor_spawned', '--state-path', statePath, '--data', '{}',
+    ).returncode).toBe(0);
+
+    const result = runLashInDir(
+      tmpDir, 'state', 'update', 'build_completed', '--state-path', statePath,
+    );
+
+    expect(result.returncode).toBe(1);
+    expect(result.stderr).toContain('build_critic_passed');
   });
 });

--- a/tests/cli-cleanup.test.ts
+++ b/tests/cli-cleanup.test.ts
@@ -272,7 +272,8 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
 
   it('rejects build_completed until critic and supervisor pass events exist', () => {
     const statePath = join(tmpDir, 'specs', 'build-state.json');
-    makeSpecsDir(tmpDir);
+    const specsDir = makeSpecsDir(tmpDir);
+    writeFileSync(join(specsDir, 'spec.json'), '{"phase":"spec"}');
 
     expect(runLashInDir(
       tmpDir, 'state', 'create', '--spec-hash', 'abc123', '--state-path', statePath,
@@ -284,6 +285,9 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
       tmpDir, 'state', 'update', 'build_critic_spawned', '--state-path', statePath, '--data', '{}',
     ).returncode).toBe(0);
     expect(runLashInDir(
+      tmpDir, 'state', 'update', 'build_critic_passed', '--state-path', statePath, '--data', '{}',
+    ).returncode).toBe(0);
+    expect(runLashInDir(
       tmpDir, 'state', 'update', 'supervisor_spawned', '--state-path', statePath, '--data', '{}',
     ).returncode).toBe(0);
 
@@ -292,6 +296,7 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
     );
 
     expect(result.returncode).toBe(1);
-    expect(result.stderr).toContain('build_critic_passed');
+    expect(result.stderr).toContain('supervisor_passed');
+    expect(existsSync(join(specsDir, 'spec.json'))).toBe(true);
   });
 });

--- a/tests/cli-cleanup.test.ts
+++ b/tests/cli-cleanup.test.ts
@@ -192,6 +192,21 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
     );
     expect(createResult.returncode).toBe(0);
 
+    const tracerResult = runLashInDir(
+      tmpDir, 'state', 'update', 'tracer_completed', '--state-path', statePath, '--data', '{}',
+    );
+    expect(tracerResult.returncode).toBe(0);
+
+    const criticResult = runLashInDir(
+      tmpDir, 'state', 'update', 'build_critic_spawned', '--state-path', statePath, '--data', '{}',
+    );
+    expect(criticResult.returncode).toBe(0);
+
+    const supervisorResult = runLashInDir(
+      tmpDir, 'state', 'update', 'supervisor_spawned', '--state-path', statePath, '--data', '{}',
+    );
+    expect(supervisorResult.returncode).toBe(0);
+
     // Trigger build_completed
     const result = runLashInDir(
       tmpDir, 'state', 'update', 'build_completed', '--state-path', statePath,
@@ -224,5 +239,24 @@ describe('TC-009: state update build_completed triggers cleanup', () => {
 
     // spec.json should still exist
     expect(existsSync(join(specsDir, 'spec.json'))).toBe(true);
+  });
+
+  it('accepts tracer_completed through CLI and advances current_phase', () => {
+    const statePath = join(tmpDir, 'specs', 'build-state.json');
+    makeSpecsDir(tmpDir);
+
+    const createResult = runLashInDir(
+      tmpDir, 'state', 'create', '--spec-hash', 'abc123', '--state-path', statePath,
+    );
+    expect(createResult.returncode).toBe(0);
+
+    const result = runLashInDir(
+      tmpDir, 'state', 'update', 'tracer_completed', '--state-path', statePath, '--data', '{}',
+    );
+
+    expect(result.returncode).toBe(0);
+    const stateOutput = JSON.parse(result.stdout);
+    expect(stateOutput.current_phase).toBe('batch_execution');
+    expect(stateOutput.tracer.status).toBe('completed');
   });
 });


### PR DESCRIPTION
## Summary
- add `tracer_completed` plus phase precondition enforcement to Lash build-state and close the verification-state transition loop
- constrain lash-build child agent prompts with explicit phase guards so tracer, batch, and verify sessions stop at their assigned stage
- sync regression coverage and Chinese user/project docs with the new Lash phase guard behavior

## Verification
- pnpm lint
- pnpm test
- pnpm build

Closes #65
Closes #66