### PR TITLE
feat: add MCP-based constraint enforcement layer

### DIFF
--- a/src/constraint/config-generator.ts
+++ b/src/constraint/config-generator.ts
@@ -1,0 +1,183 @@
+/**
+ * MOD-003: constraint/config-generator
+ *
+ * Generates per-platform MCP config files that declare the constraint-server
+ * as a stdio command. Integrates with Lash task-packager's generatePackage()
+ * flow and provides Worker Instructions with MCP tool usage guidance.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type McpPlatform = 'claude-code' | 'codex' | 'opencode';
+
+export interface McpConfigResult {
+  /** Absolute path to the written config file */
+  configPath: string;
+  /** Content written to the config file */
+  configContent: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the args array for the constraint-server stdio command.
+ * Resolves the constraint-server binary relative to this package.
+ */
+function buildServerArgs(specPath: string, moduleId: string, worktreePath: string): string[] {
+  // Reference the compiled constraint-server entry point
+  const serverBin = join(dirname(new URL(import.meta.url).pathname), 'constraint-server.js');
+  return [serverBin, '--spec', specPath, '--module', moduleId, '--workdir', worktreePath];
+}
+
+function writeConfig(configPath: string, content: string): void {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, content, 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// Platform-specific config generators
+// ---------------------------------------------------------------------------
+
+function generateClaudeCodeConfig(
+  specPath: string,
+  moduleId: string,
+  worktreePath: string,
+): McpConfigResult {
+  const configPath = join(worktreePath, '.claude', 'settings.local.json');
+  const args = buildServerArgs(specPath, moduleId, worktreePath);
+
+  const config = {
+    mcpServers: {
+      'nopilot-constraint': {
+        command: 'node',
+        args,
+      },
+    },
+  };
+
+  const configContent = JSON.stringify(config, null, 2);
+  writeConfig(configPath, configContent);
+  return { configPath, configContent };
+}
+
+function generateOpenCodeConfig(
+  specPath: string,
+  moduleId: string,
+  worktreePath: string,
+): McpConfigResult {
+  const configPath = join(worktreePath, 'opencode.json');
+  const args = buildServerArgs(specPath, moduleId, worktreePath);
+
+  const config = {
+    mcpServers: {
+      'nopilot-constraint': {
+        command: 'node',
+        args,
+      },
+    },
+  };
+
+  const configContent = JSON.stringify(config, null, 2);
+  writeConfig(configPath, configContent);
+  return { configPath, configContent };
+}
+
+function generateCodexConfig(
+  specPath: string,
+  moduleId: string,
+  worktreePath: string,
+): McpConfigResult {
+  const configPath = join(worktreePath, 'codex.json');
+  const args = buildServerArgs(specPath, moduleId, worktreePath);
+
+  // Codex uses a JSON MCP config format with mcp_servers for stdio servers
+  const config = {
+    mcp_servers: {
+      'nopilot-constraint': {
+        type: 'stdio',
+        command: 'node',
+        args,
+      },
+    },
+  };
+
+  const configContent = JSON.stringify(config, null, 2);
+  writeConfig(configPath, configContent);
+  return { configPath, configContent };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a platform-specific MCP config file that registers the
+ * nopilot-constraint server as a stdio MCP server.
+ *
+ * @param platform - Target platform: 'claude-code' | 'codex' | 'opencode'
+ * @param specPath - Absolute path to spec.json
+ * @param moduleId - Module ID being built (e.g. 'MOD-003')
+ * @param worktreePath - Absolute path to the worker worktree root
+ * @returns { configPath, configContent }
+ * @throws Error with code UNSUPPORTED_PLATFORM for unknown platforms
+ */
+export function generateMcpConfig(
+  platform: McpPlatform,
+  specPath: string,
+  moduleId: string,
+  worktreePath: string,
+): McpConfigResult {
+  switch (platform) {
+    case 'claude-code':
+      return generateClaudeCodeConfig(specPath, moduleId, worktreePath);
+    case 'opencode':
+      return generateOpenCodeConfig(specPath, moduleId, worktreePath);
+    case 'codex':
+      return generateCodexConfig(specPath, moduleId, worktreePath);
+    default: {
+      const p = platform as string;
+      throw new Error(
+        `UNSUPPORTED_PLATFORM: '${p}' is not a supported platform. ` +
+          `Expected one of: claude-code, codex, opencode`,
+      );
+    }
+  }
+}
+
+/**
+ * Returns prompt text instructing the worker agent to prefer nopilot_write_file
+ * over native Write/Edit tools when the constraint MCP server is active.
+ *
+ * @param platform - Target platform (currently returns the same text for all)
+ */
+export function getMcpWorkerInstructions(platform: McpPlatform): string {
+  return [
+    `## NoPilot Constraint Server Active (${platform})`,
+    ``,
+    `A constraint enforcement MCP server is running for this session.`,
+    ``,
+    `**Important**: Use \`nopilot_write_file\` instead of native Write or Edit tools`,
+    `when creating or modifying files. This ensures file-ownership constraints are`,
+    `enforced and violations are logged correctly.`,
+    ``,
+    `### Available MCP Tools`,
+    ``,
+    `- \`nopilot_write_file(file_path, content)\` — Write-proxy that validates path`,
+    `  against your module's owned_files before writing. Prefer this over Write/Edit.`,
+    `- \`nopilot_validate_import(source_path, import_target_path)\` — Check whether`,
+    `  an import is allowed by the dependency graph before adding it.`,
+    `- \`nopilot_read_constraints()\` — Read the full ConstraintRuleSet for this module.`,
+    ``,
+    `### Why This Matters`,
+    ``,
+    `The constraint server tracks every file write and import. Using native Write/Edit`,
+    `instead of \`nopilot_write_file\` bypasses constraint checks and produces an`,
+    `incomplete violation report. Always prefer \`nopilot_write_file\`.`,
+  ].join('\n');
+}

--- a/src/constraint/reporter.ts
+++ b/src/constraint/reporter.ts
@@ -1,0 +1,35 @@
+/**
+ * MOD-002: constraint/reporter
+ *
+ * Writes constraint-report.json to .lash/ on server exit.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import type { ConstraintReport, SessionState } from './types.js';
+
+/**
+ * Build a ConstraintReport from the current session state.
+ */
+export function buildReport(state: SessionState): ConstraintReport {
+  return {
+    moduleId: state.ruleSet.moduleId,
+    violations: state.violations,
+    counters: {
+      mcpCalls: state.mcpCallCount,
+      violationsBlocked: state.violationsBlockedCount,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * Write constraint-report.json to the .lash/ directory within workDir.
+ * Creates .lash/ if it does not exist.
+ */
+export function writeReport(workDir: string, report: ConstraintReport): string {
+  const lashDir = join(resolve(workDir), '.lash');
+  mkdirSync(lashDir, { recursive: true });
+  const reportPath = join(lashDir, 'constraint-report.json');
+  writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf8');
+  return reportPath;
+}

--- a/src/constraint/rule-engine.ts
+++ b/src/constraint/rule-engine.ts
@@ -1,0 +1,406 @@
+/**
+ * MOD-001: constraint/rule-engine
+ *
+ * Parses spec.json via spec-resolver and extracts per-module ConstraintRuleSets.
+ * Provides file-ownership validation, import-direction validation,
+ * circular dependency detection, and profile conflict checking.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { posix, resolve } from 'node:path';
+import { resolveSpec } from '../lash/spec-resolver.js';
+import type {
+  ConstraintRule,
+  ConstraintRuleSet,
+  ConstraintViolation,
+  ProfileConflict,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// Internal spec shape helpers
+// ---------------------------------------------------------------------------
+
+interface SpecModuleEntry {
+  id: string;
+  owned_files?: string[];
+  [key: string]: unknown;
+}
+
+interface SpecEdge {
+  from?: string;
+  to?: string;
+}
+
+interface SpecShape {
+  modules?: SpecModuleEntry[];
+  dependency_graph?: { edges?: SpecEdge[] };
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Path normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a file path to forward-slash relative form.
+ * Resolves ../ sequences relative to cwd, then converts to posix.
+ */
+function normalizePath(filePath: string): string {
+  // Replace backslashes, then resolve ../ traversal
+  const withForwardSlashes = filePath.replace(/\\/g, '/');
+  // Use posix.normalize to clean up ../ and ./
+  const normalized = posix.normalize(withForwardSlashes);
+  // Remove leading slash if present (ensure relative)
+  return normalized.startsWith('/') ? normalized.slice(1) : normalized;
+}
+
+/**
+ * Check whether a file path matches an owned_files entry.
+ * owned_files entries can be exact paths or glob-style with ** wildcards.
+ */
+function matchesOwnedFile(filePath: string, ownedPattern: string): boolean {
+  const normalFile = normalizePath(filePath);
+  const normalPattern = normalizePath(ownedPattern);
+
+  if (normalPattern === normalFile) return true;
+
+  // Simple glob: pattern ends with /** — match any file under that directory
+  if (normalPattern.endsWith('/**')) {
+    const prefix = normalPattern.slice(0, -3);
+    return normalFile === prefix || normalFile.startsWith(prefix + '/');
+  }
+
+  // Pattern ends with /* — match direct children only
+  if (normalPattern.endsWith('/*')) {
+    const prefix = normalPattern.slice(0, -2);
+    const rest = normalFile.slice(prefix.length + 1);
+    return normalFile.startsWith(prefix + '/') && !rest.includes('/');
+  }
+
+  // Treat as directory prefix if pattern has no extension and no glob
+  if (!normalPattern.includes('*') && !normalPattern.includes('.')) {
+    return normalFile.startsWith(normalPattern + '/');
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// extractRules
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse spec.json via spec-resolver and build a ConstraintRuleSet for moduleId.
+ *
+ * @throws Error with SPEC_NOT_FOUND, SPEC_MALFORMED, MODULE_NOT_FOUND
+ */
+export function extractRules(specPath: string, moduleId: string): ConstraintRuleSet {
+  // spec-resolver throws PATH_NOT_FOUND if path doesn't exist
+  let spec: SpecShape;
+  try {
+    const resolved = resolveSpec(specPath);
+    spec = resolved.spec as SpecShape;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('PATH_NOT_FOUND') || msg.includes('INDEX_MISSING')) {
+      throw new Error(`[SPEC_NOT_FOUND] ${msg}`);
+    }
+    if (msg.includes('INVALID_JSON')) {
+      throw new Error(`[SPEC_MALFORMED] ${msg}`);
+    }
+    throw new Error(`[SPEC_MALFORMED] Failed to load spec: ${msg}`);
+  }
+
+  // Validate spec structure
+  if (!Array.isArray(spec.modules) || spec.modules.length === 0) {
+    throw new Error('[SPEC_MALFORMED] spec.json missing required "modules" array');
+  }
+
+  // Find target module
+  const targetModule = spec.modules.find((m) => m.id === moduleId);
+  if (!targetModule) {
+    throw new Error(`[MODULE_NOT_FOUND] Module "${moduleId}" not found in spec.modules[]`);
+  }
+
+  const ownedFiles: string[] = (targetModule.owned_files ?? []).map(normalizePath);
+
+  // Build allModules list
+  const allModules = spec.modules.map((m) => ({
+    id: m.id,
+    ownedFiles: (m.owned_files ?? []).map(normalizePath),
+  }));
+
+  // Build dependency edges
+  const edges = spec.dependency_graph?.edges ?? [];
+  const dependencyEdges = edges
+    .filter((e) => typeof e.from === 'string' && typeof e.to === 'string')
+    .map((e) => ({ from: e.from as string, to: e.to as string }));
+
+  // Build allowedDependencies: modules reachable from moduleId via dependency edges
+  const allowedDependencies = dependencyEdges
+    .filter((e) => e.from === moduleId)
+    .map((e) => {
+      const depModule = spec.modules!.find((m) => m.id === e.to);
+      return {
+        moduleId: e.to,
+        ownedFiles: (depModule?.owned_files ?? []).map(normalizePath),
+      };
+    });
+
+  // Build rules
+  const rules: ConstraintRule[] = [];
+
+  // Rule: file_ownership
+  rules.push({
+    id: `file-ownership-${moduleId}`,
+    type: 'file_ownership',
+    moduleId,
+    description: `Files written during this session must belong to module ${moduleId}'s owned_files set`,
+  });
+
+  // Rules: import_direction for each dependency edge from this module
+  for (const dep of allowedDependencies) {
+    rules.push({
+      id: `import-direction-${moduleId}-${dep.moduleId}`,
+      type: 'import_direction',
+      moduleId,
+      description: `Imports from ${moduleId} to ${dep.moduleId} are allowed via dependency_graph edge`,
+    });
+  }
+
+  // Rule: circular_dep
+  rules.push({
+    id: `circular-dep-${moduleId}`,
+    type: 'circular_dep',
+    moduleId,
+    description: `Circular dependencies involving ${moduleId} are prohibited`,
+  });
+
+  return {
+    moduleId,
+    ownedFiles,
+    allowedDependencies,
+    allModules,
+    dependencyEdges,
+    rules,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// checkFileOwnership
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether filePath is within the module's owned_files.
+ * Returns { allowed: true, violation: null } or { allowed: false, violation }.
+ */
+export function checkFileOwnership(
+  ruleSet: ConstraintRuleSet,
+  filePath: string,
+): { allowed: boolean; violation: ConstraintViolation | null } {
+  const normalized = normalizePath(filePath);
+
+  const isOwned = ruleSet.ownedFiles.some((pattern) => matchesOwnedFile(normalized, pattern));
+  if (isOwned) {
+    return { allowed: true, violation: null };
+  }
+
+  // Find which module owns this path
+  const owningModule = ruleSet.allModules.find(
+    (m) => m.id !== ruleSet.moduleId && m.ownedFiles.some((p) => matchesOwnedFile(normalized, p)),
+  );
+
+  const owningModuleId = owningModule?.id ?? null;
+
+  const suggestedFix = owningModuleId
+    ? `This file belongs to module ${owningModuleId}. Move it to your module's directory or update the spec to add it to your owned_files.`
+    : `This file is not owned by any module. Move it to your module's directory or update the spec to add it to module ${ruleSet.moduleId}'s owned_files.`;
+
+  const violation: ConstraintViolation = {
+    ruleId: `file-ownership-${ruleSet.moduleId}`,
+    ruleType: 'file_ownership',
+    violatingPath: normalized,
+    owningModuleId,
+    suggestedFix,
+  };
+
+  return { allowed: false, violation };
+}
+
+// ---------------------------------------------------------------------------
+// validateImport
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate whether an import from sourcePath to importTargetPath is allowed.
+ * Both paths are resolved to their owning modules, then checked against dependency_graph.
+ *
+ * @throws Error with UNRESOLVABLE_PATH if either path cannot be mapped to a module
+ */
+export function validateImport(
+  ruleSet: ConstraintRuleSet,
+  sourcePath: string,
+  importTargetPath: string,
+): { allowed: boolean; violation: ConstraintViolation | null } {
+  const normalSource = normalizePath(sourcePath);
+  const normalTarget = normalizePath(importTargetPath);
+
+  // Resolve source to module
+  const sourceModule = ruleSet.allModules.find((m) =>
+    m.ownedFiles.some((p) => matchesOwnedFile(normalSource, p)),
+  );
+  if (!sourceModule) {
+    throw new Error(
+      `[UNRESOLVABLE_PATH] Source path "${normalSource}" cannot be mapped to any module`,
+    );
+  }
+
+  // Resolve target to module
+  const targetModule = ruleSet.allModules.find((m) =>
+    m.ownedFiles.some((p) => matchesOwnedFile(normalTarget, p)),
+  );
+  if (!targetModule) {
+    throw new Error(
+      `[UNRESOLVABLE_PATH] Import target path "${normalTarget}" cannot be mapped to any module`,
+    );
+  }
+
+  // Same module — always allowed
+  if (sourceModule.id === targetModule.id) {
+    return { allowed: true, violation: null };
+  }
+
+  // Check if there is an edge from sourceModule to targetModule
+  const hasEdge = ruleSet.dependencyEdges.some(
+    (e) => e.from === sourceModule.id && e.to === targetModule.id,
+  );
+
+  if (hasEdge) {
+    return { allowed: true, violation: null };
+  }
+
+  const allowedDeps = ruleSet.dependencyEdges
+    .filter((e) => e.from === sourceModule.id)
+    .map((e) => e.to)
+    .join(', ') || 'none';
+
+  const violation: ConstraintViolation = {
+    ruleId: `import-direction-${sourceModule.id}`,
+    ruleType: 'import_direction',
+    violatingPath: normalTarget,
+    owningModuleId: targetModule.id,
+    suggestedFix: `Module ${sourceModule.id} is not allowed to import from ${targetModule.id}. Allowed dependencies: [${allowedDeps}]. Update dependency_graph.edges in spec.json to allow this import.`,
+  };
+
+  return { allowed: false, violation };
+}
+
+// ---------------------------------------------------------------------------
+// detectCycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether adding an edge from -> to would create a cycle in the dependency graph.
+ * Uses DFS reachability from `toModuleId` back to `fromModuleId`.
+ */
+export function detectCycle(
+  ruleSet: ConstraintRuleSet,
+  fromModuleId: string,
+  toModuleId: string,
+): { hasCycle: boolean; cyclePath: string[] | null } {
+  // Build adjacency map from existing edges
+  const adj = new Map<string, string[]>();
+  for (const edge of ruleSet.dependencyEdges) {
+    if (!adj.has(edge.from)) adj.set(edge.from, []);
+    adj.get(edge.from)!.push(edge.to);
+  }
+
+  // DFS from toModuleId to see if we can reach fromModuleId
+  // (which would mean adding from->to creates a cycle)
+  const visited = new Set<string>();
+  const path: string[] = [toModuleId];
+
+  function dfs(current: string): string[] | null {
+    if (current === fromModuleId) {
+      // Found cycle: complete the cycle by adding fromModuleId at the end
+      return [...path, fromModuleId];
+    }
+    visited.add(current);
+    const neighbors = adj.get(current) ?? [];
+    for (const neighbor of neighbors) {
+      if (!visited.has(neighbor)) {
+        path.push(neighbor);
+        const result = dfs(neighbor);
+        if (result !== null) return result;
+        path.pop();
+      }
+    }
+    return null;
+  }
+
+  const cyclePath = dfs(toModuleId);
+  if (cyclePath !== null) {
+    return { hasCycle: true, cyclePath };
+  }
+
+  return { hasCycle: false, cyclePath: null };
+}
+
+// ---------------------------------------------------------------------------
+// checkProfileConflicts
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare constraint rules against profile L2 decisions.
+ * Returns conflicts and skipped rule IDs.
+ * Non-fatal if profile file does not exist (returns empty conflicts).
+ */
+export function checkProfileConflicts(
+  ruleSet: ConstraintRuleSet,
+  profileL2Path: string,
+): { conflicts: ProfileConflict[]; skippedRuleIds: string[] } {
+  const absPath = resolve(profileL2Path);
+
+  if (!existsSync(absPath)) {
+    return { conflicts: [], skippedRuleIds: [] };
+  }
+
+  let l2Data: Record<string, unknown>;
+  try {
+    const text = readFileSync(absPath, 'utf8');
+    l2Data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { conflicts: [], skippedRuleIds: [] };
+  }
+
+  const conflicts: ProfileConflict[] = [];
+  const skippedRuleIds: string[] = [];
+
+  // L2 decisions are structured as an array of constraint decisions
+  const decisions = Array.isArray(l2Data['decisions']) ? l2Data['decisions'] : [];
+
+  for (const decision of decisions as Record<string, unknown>[]) {
+    const decisionType = String(decision['type'] ?? '');
+    const decisionDescription = String(decision['description'] ?? '');
+
+    // Check each import_direction rule against profile constraints
+    for (const rule of ruleSet.rules) {
+      if (rule.type !== 'import_direction') continue;
+
+      // If profile prohibits a dependency that spec allows
+      if (
+        decisionType === 'prohibit_dependency' &&
+        decisionDescription.includes(rule.id)
+      ) {
+        conflicts.push({
+          ruleId: rule.id,
+          profileEntry: decisionDescription,
+          description: `Constraint rule "${rule.id}" conflicts with profile L2 decision: "${decisionDescription}"`,
+          resolution: 'pending',
+        });
+        skippedRuleIds.push(rule.id);
+      }
+    }
+  }
+
+  return { conflicts, skippedRuleIds };
+}

--- a/src/constraint/server.ts
+++ b/src/constraint/server.ts
@@ -1,0 +1,170 @@
+/**
+ * MOD-002: constraint/server
+ *
+ * MCP server running as agent child process via stdio transport.
+ * Exposes 3 MCP tools: nopilot_write_file, nopilot_validate_import, nopilot_read_constraints.
+ * Writes constraint-report.json to .lash/ on exit.
+ *
+ * Entry point: node constraint-server.js --spec <path> --module <id> --workdir <path>
+ */
+import { Server } from '@modelcontextprotocol/sdk/server';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+} from '@modelcontextprotocol/sdk/types';
+import { extractRules } from './rule-engine.js';
+import { handleWriteFile, handleValidateImport, handleReadConstraints } from './tools.js';
+import { buildReport, writeReport } from './reporter.js';
+import type { SessionState } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Server state machine: initializing -> ready -> processing -> shutting_down
+// ---------------------------------------------------------------------------
+
+export type ServerPhase = 'initializing' | 'ready' | 'processing' | 'shutting_down';
+
+export interface ConstraintServerOptions {
+  specPath: string;
+  moduleId: string;
+  workDir: string;
+}
+
+/**
+ * Create and start the constraint MCP server.
+ * Returns the server instance for testing.
+ */
+export async function startServer(options: ConstraintServerOptions): Promise<Server> {
+  const { specPath, moduleId, workDir } = options;
+
+  let phase: ServerPhase = 'initializing';
+
+  // Initialize rule set — exit on failure
+  let ruleSet;
+  try {
+    ruleSet = extractRules(specPath, moduleId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[ERROR] constraint-server: INIT_FAILED — ${msg}\n`);
+    process.exit(1);
+  }
+
+  const sessionState: SessionState = {
+    ruleSet,
+    violations: [],
+    mcpCallCount: 0,
+    violationsBlockedCount: 0,
+  };
+
+  phase = 'ready';
+
+  // Create MCP server
+  const server = new Server(
+    { name: 'nopilot-constraint-server', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+
+  // List tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: 'nopilot_write_file',
+          description:
+            'Write proxy: validates file path against module owned_files before writing. Blocks writes to non-owned paths.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              file_path: { type: 'string', description: 'Path to write (absolute or relative)' },
+              content: { type: 'string', description: 'File content to write' },
+            },
+            required: ['file_path', 'content'],
+          },
+        },
+        {
+          name: 'nopilot_validate_import',
+          description:
+            'Validate whether an import from source_path to import_target_path is allowed by the dependency graph.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              source_path: { type: 'string', description: 'File that contains the import' },
+              import_target_path: { type: 'string', description: 'The imported file path' },
+            },
+            required: ['source_path', 'import_target_path'],
+          },
+        },
+        {
+          name: 'nopilot_read_constraints',
+          description:
+            'Read the full ConstraintRuleSet for the current module: owned files, allowed dependencies, rule count.',
+          inputSchema: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      ],
+    };
+  });
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+    phase = 'processing';
+    const { name, arguments: args } = request.params;
+
+    let result;
+    try {
+      if (name === 'nopilot_write_file') {
+        const input = args as { file_path: string; content: string };
+        result = handleWriteFile(sessionState, workDir, {
+          file_path: input.file_path,
+          content: input.content,
+        });
+      } else if (name === 'nopilot_validate_import') {
+        const input = args as { source_path: string; import_target_path: string };
+        result = handleValidateImport(sessionState, {
+          source_path: input.source_path,
+          import_target_path: input.import_target_path,
+        });
+      } else if (name === 'nopilot_read_constraints') {
+        result = handleReadConstraints(sessionState);
+      } else {
+        result = {
+          content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+      }
+    } finally {
+      phase = 'ready';
+    }
+
+    return result! as CallToolResult;
+  });
+
+  // Write report on process exit
+  const writeReportAndExit = () => {
+    phase = 'shutting_down';
+    const report = buildReport(sessionState);
+    try {
+      writeReport(workDir, report);
+      process.stderr.write(
+        `[INFO] constraint-server: session ended — mcpCalls=${report.counters.mcpCalls}, blocked=${report.counters.violationsBlocked}\n`,
+      );
+    } catch (err) {
+      process.stderr.write(`[WARN] constraint-server: failed to write report: ${err}\n`);
+    }
+  };
+
+  process.on('exit', writeReportAndExit);
+  process.on('SIGTERM', () => {
+    writeReportAndExit();
+    process.exit(0);
+  });
+
+  // Connect via stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  return server;
+}

--- a/src/constraint/tools.ts
+++ b/src/constraint/tools.ts
@@ -1,0 +1,203 @@
+/**
+ * MOD-002: constraint/tools
+ *
+ * MCP tool handler implementations for the constraint enforcement server.
+ * Delegates constraint checks to rule-engine. Manages session violation log.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve, posix } from 'node:path';
+import { checkFileOwnership, validateImport, detectCycle } from './rule-engine.js';
+import type { ConstraintViolation, SessionState } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Path normalization (forward-slash relative)
+// ---------------------------------------------------------------------------
+
+function normalizePath(filePath: string, workDir: string): string {
+  // Replace backslashes
+  const withSlashes = filePath.replace(/\\/g, '/');
+  // Normalize ../ and ./
+  const normalized = posix.normalize(withSlashes);
+  // Remove leading slash if absolute
+  return normalized.startsWith('/') ? normalized.slice(1) : normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Tool: nopilot_write_file
+// ---------------------------------------------------------------------------
+
+export interface WriteFileInput {
+  file_path: string;
+  content: string;
+}
+
+export interface WriteFileResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: boolean;
+}
+
+/**
+ * Write proxy: validates path against owned_files BEFORE any I/O.
+ * Executes write only if validation passes.
+ */
+export function handleWriteFile(
+  state: SessionState,
+  workDir: string,
+  input: WriteFileInput,
+): WriteFileResult {
+  state.mcpCallCount += 1;
+
+  const normalizedPath = normalizePath(input.file_path, workDir);
+  const { allowed, violation } = checkFileOwnership(state.ruleSet, normalizedPath);
+
+  if (!allowed && violation !== null) {
+    state.violations.push(violation);
+    state.violationsBlockedCount += 1;
+    return {
+      content: [{ type: 'text', text: JSON.stringify(violation) }],
+      isError: true,
+    };
+  }
+
+  // Write is allowed — execute it
+  const absPath = resolve(workDir, normalizedPath);
+  try {
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, input.content, 'utf8');
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ error: `WRITE_FAILED: ${errMsg}`, code: 'WRITE_FAILED' }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  return {
+    content: [{ type: 'text', text: `Written: ${normalizedPath}` }],
+    isError: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool: nopilot_validate_import
+// ---------------------------------------------------------------------------
+
+export interface ValidateImportInput {
+  source_path: string;
+  import_target_path: string;
+}
+
+export interface ValidateImportResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: boolean;
+}
+
+export function handleValidateImport(
+  state: SessionState,
+  input: ValidateImportInput,
+): ValidateImportResult {
+  state.mcpCallCount += 1;
+
+  let importResult: { allowed: boolean; violation: ConstraintViolation | null };
+  try {
+    importResult = validateImport(state.ruleSet, input.source_path, input.import_target_path);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ error: errMsg, code: 'UNRESOLVABLE_PATH' }) }],
+      isError: true,
+    };
+  }
+
+  // Also check for cycle
+  let cycleResult: { hasCycle: boolean; cyclePath: string[] | null } = {
+    hasCycle: false,
+    cyclePath: null,
+  };
+
+  // Resolve source and target to modules for cycle check
+  const normalSource = input.source_path.replace(/\\/g, '/');
+  const normalTarget = input.import_target_path.replace(/\\/g, '/');
+  const sourceModule = state.ruleSet.allModules.find((m) =>
+    m.ownedFiles.some((p) => normalSource.startsWith(p.replace('/**', '').replace('/*', ''))),
+  );
+  const targetModule = state.ruleSet.allModules.find((m) =>
+    m.ownedFiles.some((p) => normalTarget.startsWith(p.replace('/**', '').replace('/*', ''))),
+  );
+
+  if (sourceModule && targetModule && sourceModule.id !== targetModule.id) {
+    cycleResult = detectCycle(state.ruleSet, sourceModule.id, targetModule.id);
+  }
+
+  const response = {
+    allowed: importResult.allowed && !cycleResult.hasCycle,
+    violation: importResult.violation ?? (cycleResult.hasCycle
+      ? ({
+          ruleId: `circular-dep-${sourceModule?.id ?? 'unknown'}`,
+          ruleType: 'circular_dep' as const,
+          violatingPath: normalTarget,
+          owningModuleId: targetModule?.id ?? null,
+          suggestedFix: `This import would create a circular dependency: ${cycleResult.cyclePath?.join(' -> ')}. Refactor to break the cycle.`,
+        } satisfies ConstraintViolation)
+      : null),
+    cycle_detected: cycleResult.hasCycle,
+    cycle_path: cycleResult.cyclePath,
+  };
+
+  if (!response.allowed && response.violation) {
+    state.violations.push(response.violation);
+    state.violationsBlockedCount += 1;
+  }
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(response) }],
+    isError: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tool: nopilot_read_constraints
+// ---------------------------------------------------------------------------
+
+export interface ReadConstraintsResult {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: boolean;
+}
+
+export function handleReadConstraints(state: SessionState | null): ReadConstraintsResult {
+  if (state === null) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            error: 'NO_MODULE_CONTEXT: constraint server has no valid module context',
+            code: 'NO_MODULE_CONTEXT',
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+
+  const { ruleSet } = state;
+  const response = {
+    moduleId: ruleSet.moduleId,
+    ownedFiles: ruleSet.ownedFiles,
+    allowedDependencies: ruleSet.allowedDependencies.map((d) => ({
+      moduleId: d.moduleId,
+      name: d.moduleId,
+    })),
+    ruleCount: ruleSet.rules.length,
+  };
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(response) }],
+    isError: false,
+  };
+}

--- a/src/constraint/types.ts
+++ b/src/constraint/types.ts
@@ -1,0 +1,64 @@
+/**
+ * MOD-001: constraint/types
+ *
+ * Shared TypeScript type definitions for the constraint enforcement layer.
+ * All types are derived from spec.json data_models.
+ */
+
+// ---------------------------------------------------------------------------
+// Core constraint types
+// ---------------------------------------------------------------------------
+
+export type ConstraintRuleType = 'file_ownership' | 'import_direction' | 'circular_dep';
+
+export interface ConstraintRule {
+  id: string;
+  type: ConstraintRuleType;
+  moduleId: string;
+  description: string;
+}
+
+export interface ConstraintRuleSet {
+  moduleId: string;
+  ownedFiles: string[];
+  allowedDependencies: { moduleId: string; ownedFiles: string[] }[];
+  allModules: { id: string; ownedFiles: string[] }[];
+  dependencyEdges: { from: string; to: string }[];
+  rules: ConstraintRule[];
+}
+
+export interface ConstraintViolation {
+  ruleId: string;
+  ruleType: ConstraintRuleType;
+  violatingPath: string;
+  owningModuleId: string | null;
+  suggestedFix: string;
+}
+
+export interface ProfileConflict {
+  ruleId: string;
+  profileEntry: string;
+  description: string;
+  resolution: 'pending';
+}
+
+// ---------------------------------------------------------------------------
+// Session and report types (used by MOD-002)
+// ---------------------------------------------------------------------------
+
+export interface ConstraintReport {
+  moduleId: string;
+  violations: ConstraintViolation[];
+  counters: {
+    mcpCalls: number;
+    violationsBlocked: number;
+  };
+  timestamp: string;
+}
+
+export interface SessionState {
+  ruleSet: ConstraintRuleSet;
+  violations: ConstraintViolation[];
+  mcpCallCount: number;
+  violationsBlockedCount: number;
+}

--- a/tests/constraint/config-generator.test.ts
+++ b/tests/constraint/config-generator.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for MOD-003: constraint/config-generator
+ * Covers TEST-001, TEST-024, TEST-025, TEST-033, TEST-034
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateMcpConfig, getMcpWorkerInstructions } from '../../src/constraint/config-generator.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'config-gen-test-'));
+}
+
+// ---------------------------------------------------------------------------
+// TEST-001: generateMcpConfig writes Claude Code MCP config with correct structure
+// ---------------------------------------------------------------------------
+
+describe('generateMcpConfig - claude-code', () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = makeTmpDir();
+  });
+
+  it('TEST-001: writes .claude/settings.local.json with correct mcpServers structure', () => {
+    const specPath = '/path/to/spec.json';
+    const moduleId = 'MOD-003';
+
+    const result = generateMcpConfig('claude-code', specPath, moduleId, worktreePath);
+
+    expect(result.configPath).toBe(join(worktreePath, '.claude', 'settings.local.json'));
+    expect(existsSync(result.configPath)).toBe(true);
+
+    const config = JSON.parse(readFileSync(result.configPath, 'utf8'));
+    expect(config).toHaveProperty('mcpServers');
+    expect(config.mcpServers).toHaveProperty('nopilot-constraint');
+
+    const server = config.mcpServers['nopilot-constraint'];
+    expect(server.command).toBe('node');
+    expect(Array.isArray(server.args)).toBe(true);
+
+    // Args must include the spec path, module id, and workdir
+    const argsStr = server.args.join(' ');
+    expect(argsStr).toContain('--spec');
+    expect(argsStr).toContain(specPath);
+    expect(argsStr).toContain('--module');
+    expect(argsStr).toContain(moduleId);
+    expect(argsStr).toContain('--workdir');
+    expect(argsStr).toContain(worktreePath);
+  });
+
+  it('configContent matches what is written to disk', () => {
+    const result = generateMcpConfig('claude-code', '/spec.json', 'MOD-001', worktreePath);
+    const onDisk = readFileSync(result.configPath, 'utf8');
+    expect(result.configContent).toBe(onDisk);
+  });
+
+  it('returns configPath pointing inside worktreePath', () => {
+    const result = generateMcpConfig('claude-code', '/spec.json', 'MOD-001', worktreePath);
+    expect(result.configPath.startsWith(worktreePath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-033: generateMcpConfig produces valid Codex config
+// ---------------------------------------------------------------------------
+
+describe('generateMcpConfig - codex', () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = makeTmpDir();
+  });
+
+  it('TEST-033: writes codex MCP config file with stdio server entry', () => {
+    const specPath = '/path/to/spec.json';
+    const moduleId = 'MOD-003';
+
+    const result = generateMcpConfig('codex', specPath, moduleId, worktreePath);
+
+    expect(existsSync(result.configPath)).toBe(true);
+    expect(result.configPath.startsWith(worktreePath)).toBe(true);
+
+    // Config content must reference the nopilot-constraint server and key args
+    expect(result.configContent).toContain('nopilot-constraint');
+    expect(result.configContent).toContain(specPath);
+    expect(result.configContent).toContain(moduleId);
+    expect(result.configContent).toContain(worktreePath);
+  });
+
+  it('configContent matches what is written to disk', () => {
+    const result = generateMcpConfig('codex', '/spec.json', 'MOD-002', worktreePath);
+    const onDisk = readFileSync(result.configPath, 'utf8');
+    expect(result.configContent).toBe(onDisk);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-034: generateMcpConfig produces valid OpenCode config
+// ---------------------------------------------------------------------------
+
+describe('generateMcpConfig - opencode', () => {
+  let worktreePath: string;
+
+  beforeEach(() => {
+    worktreePath = makeTmpDir();
+  });
+
+  it('TEST-034: writes opencode.json with mcpServers entry', () => {
+    const specPath = '/path/to/spec.json';
+    const moduleId = 'MOD-003';
+
+    const result = generateMcpConfig('opencode', specPath, moduleId, worktreePath);
+
+    expect(result.configPath).toBe(join(worktreePath, 'opencode.json'));
+    expect(existsSync(result.configPath)).toBe(true);
+
+    const config = JSON.parse(readFileSync(result.configPath, 'utf8'));
+    expect(config).toHaveProperty('mcpServers');
+    expect(config.mcpServers).toHaveProperty('nopilot-constraint');
+
+    const server = config.mcpServers['nopilot-constraint'];
+    expect(server.command).toBe('node');
+    expect(Array.isArray(server.args)).toBe(true);
+
+    const argsStr = server.args.join(' ');
+    expect(argsStr).toContain('--spec');
+    expect(argsStr).toContain(specPath);
+    expect(argsStr).toContain('--module');
+    expect(argsStr).toContain(moduleId);
+    expect(argsStr).toContain('--workdir');
+    expect(argsStr).toContain(worktreePath);
+  });
+
+  it('configContent matches what is written to disk', () => {
+    const result = generateMcpConfig('opencode', '/spec.json', 'MOD-001', worktreePath);
+    const onDisk = readFileSync(result.configPath, 'utf8');
+    expect(result.configContent).toBe(onDisk);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UNSUPPORTED_PLATFORM error
+// ---------------------------------------------------------------------------
+
+describe('generateMcpConfig - unsupported platform', () => {
+  it('throws UNSUPPORTED_PLATFORM for unknown platform', () => {
+    const worktreePath = makeTmpDir();
+    expect(() =>
+      generateMcpConfig('unknown-platform' as never, '/spec.json', 'MOD-001', worktreePath),
+    ).toThrow(/UNSUPPORTED_PLATFORM/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-024: Worker proceeds normally when MCP config absent (graceful degradation)
+// ---------------------------------------------------------------------------
+
+describe('getMcpWorkerInstructions', () => {
+  it('TEST-024: returns non-empty instruction string for claude-code', () => {
+    const instructions = getMcpWorkerInstructions('claude-code');
+    expect(typeof instructions).toBe('string');
+    expect(instructions.length).toBeGreaterThan(0);
+  });
+
+  it('instructions mention nopilot_write_file tool', () => {
+    const instructions = getMcpWorkerInstructions('claude-code');
+    expect(instructions).toContain('nopilot_write_file');
+  });
+
+  it('instructions advise preferring nopilot_write_file over native Write/Edit', () => {
+    const instructions = getMcpWorkerInstructions('claude-code');
+    // Should mention preference over native write/edit tools
+    const lower = instructions.toLowerCase();
+    expect(lower).toMatch(/prefer|instead|use.*nopilot|nopilot.*instead/);
+  });
+
+  it('returns instruction string for codex', () => {
+    const instructions = getMcpWorkerInstructions('codex');
+    expect(typeof instructions).toBe('string');
+    expect(instructions).toContain('nopilot_write_file');
+  });
+
+  it('returns instruction string for opencode', () => {
+    const instructions = getMcpWorkerInstructions('opencode');
+    expect(typeof instructions).toBe('string');
+    expect(instructions).toContain('nopilot_write_file');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-025: owned_files.txt format unchanged with constraint server
+// This validates that generateMcpConfig does NOT modify the owned_files listing —
+// it only writes config files (settings.local.json, codex config, opencode.json).
+// ---------------------------------------------------------------------------
+
+describe('TEST-025: generateMcpConfig does not create owned_files.txt', () => {
+  it('does not create owned_files.txt in worktree', () => {
+    const worktreePath = makeTmpDir();
+    generateMcpConfig('claude-code', '/spec.json', 'MOD-001', worktreePath);
+    expect(existsSync(join(worktreePath, 'owned_files.txt'))).toBe(false);
+  });
+
+  it('only creates the platform-specific config file', () => {
+    const worktreePath = makeTmpDir();
+    const result = generateMcpConfig('opencode', '/spec.json', 'MOD-001', worktreePath);
+    // The only new file should be opencode.json
+    expect(result.configPath).toBe(join(worktreePath, 'opencode.json'));
+    expect(existsSync(join(worktreePath, 'owned_files.txt'))).toBe(false);
+  });
+});

--- a/tests/constraint/rule-engine.test.ts
+++ b/tests/constraint/rule-engine.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for MOD-001: constraint/rule-engine
+ * Covers TEST-011 to TEST-015, TEST-019, TEST-020, TEST-022, TEST-023
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  extractRules,
+  checkFileOwnership,
+  validateImport,
+  detectCycle,
+  checkProfileConflicts,
+} from '../../src/constraint/rule-engine.js';
+import type { ConstraintRuleSet } from '../../src/constraint/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'rule-engine-test-'));
+}
+
+function writeJson(path: string, data: unknown): void {
+  writeFileSync(path, JSON.stringify(data, null, 2));
+}
+
+/** Create a 3-module fixture spec with 2 edges: MOD-A->MOD-B, MOD-B->MOD-C */
+function makeFixtureSpec(dir: string): string {
+  const spec = {
+    phase: 'spec',
+    version: '4.0',
+    modules: [
+      {
+        id: 'MOD-A',
+        name: 'alpha',
+        owned_files: ['src/a/index.ts', 'src/a/helper.ts'],
+        source_root: 'src/a/',
+      },
+      {
+        id: 'MOD-B',
+        name: 'beta',
+        owned_files: ['src/b/index.ts'],
+        source_root: 'src/b/',
+      },
+      {
+        id: 'MOD-C',
+        name: 'gamma',
+        owned_files: ['src/c/index.ts'],
+        source_root: 'src/c/',
+      },
+    ],
+    dependency_graph: {
+      edges: [
+        { from: 'MOD-A', to: 'MOD-B' },
+        { from: 'MOD-B', to: 'MOD-C' },
+      ],
+    },
+  };
+  const p = join(dir, 'spec.json');
+  writeJson(p, spec);
+  return p;
+}
+
+/** Build a minimal ConstraintRuleSet manually for unit tests that don't need extractRules */
+function buildRuleSet(overrides?: Partial<ConstraintRuleSet>): ConstraintRuleSet {
+  return {
+    moduleId: 'MOD-A',
+    ownedFiles: ['src/a/index.ts', 'src/a/helper.ts'],
+    allowedDependencies: [{ moduleId: 'MOD-B', ownedFiles: ['src/b/index.ts'] }],
+    allModules: [
+      { id: 'MOD-A', ownedFiles: ['src/a/index.ts', 'src/a/helper.ts'] },
+      { id: 'MOD-B', ownedFiles: ['src/b/index.ts'] },
+      { id: 'MOD-C', ownedFiles: ['src/c/index.ts'] },
+    ],
+    dependencyEdges: [
+      { from: 'MOD-A', to: 'MOD-B' },
+      { from: 'MOD-B', to: 'MOD-C' },
+    ],
+    rules: [
+      { id: 'file-ownership-MOD-A', type: 'file_ownership', moduleId: 'MOD-A', description: 'file ownership' },
+      { id: 'import-direction-MOD-A-MOD-B', type: 'import_direction', moduleId: 'MOD-A', description: 'import direction' },
+      { id: 'circular-dep-MOD-A', type: 'circular_dep', moduleId: 'MOD-A', description: 'circular dep' },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TEST-011: extractRules produces ConstraintRuleSet from spec
+// ---------------------------------------------------------------------------
+
+describe('extractRules', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  it('TEST-011: produces ConstraintRuleSet with owned_files, allowedDependencies, and rules', () => {
+    const specPath = makeFixtureSpec(tmpDir);
+    const ruleSet = extractRules(specPath, 'MOD-A');
+
+    expect(ruleSet.moduleId).toBe('MOD-A');
+    expect(ruleSet.ownedFiles).toContain('src/a/index.ts');
+    expect(ruleSet.ownedFiles).toContain('src/a/helper.ts');
+    expect(ruleSet.allowedDependencies).toHaveLength(1);
+    expect(ruleSet.allowedDependencies[0].moduleId).toBe('MOD-B');
+    expect(ruleSet.rules.length).toBeGreaterThan(0);
+    expect(ruleSet.rules.some((r) => r.type === 'file_ownership')).toBe(true);
+  });
+
+  it('TEST-012: extractRules works with only spec.json (no other config files)', () => {
+    const cleanDir = makeTmpDir();
+    const specPath = makeFixtureSpec(cleanDir);
+    // No .nopilot/ or any other config — should work fine
+    const ruleSet = extractRules(specPath, 'MOD-B');
+    expect(ruleSet.moduleId).toBe('MOD-B');
+    expect(ruleSet.ownedFiles).toEqual(['src/b/index.ts']);
+  });
+
+  it('TEST-013: extractRules throws descriptive error for malformed spec', () => {
+    const badSpecPath = join(tmpDir, 'malformed.json');
+    writeJson(badSpecPath, { phase: 'spec' }); // missing modules array
+
+    expect(() => extractRules(badSpecPath, 'MOD-A')).toThrow(/SPEC_MALFORMED/);
+  });
+
+  it('throws SPEC_NOT_FOUND for missing spec path', () => {
+    expect(() => extractRules('/nonexistent/spec.json', 'MOD-A')).toThrow(/SPEC_NOT_FOUND/);
+  });
+
+  it('throws MODULE_NOT_FOUND for unknown moduleId', () => {
+    const specPath = makeFixtureSpec(tmpDir);
+    expect(() => extractRules(specPath, 'MOD-UNKNOWN')).toThrow(/MODULE_NOT_FOUND/);
+  });
+
+  it('allModules contains all modules from spec', () => {
+    const specPath = makeFixtureSpec(tmpDir);
+    const ruleSet = extractRules(specPath, 'MOD-A');
+    expect(ruleSet.allModules).toHaveLength(3);
+    expect(ruleSet.allModules.map((m) => m.id)).toContain('MOD-A');
+    expect(ruleSet.allModules.map((m) => m.id)).toContain('MOD-B');
+    expect(ruleSet.allModules.map((m) => m.id)).toContain('MOD-C');
+  });
+
+  it('dependencyEdges contains all edges from spec', () => {
+    const specPath = makeFixtureSpec(tmpDir);
+    const ruleSet = extractRules(specPath, 'MOD-A');
+    expect(ruleSet.dependencyEdges).toHaveLength(2);
+    expect(ruleSet.dependencyEdges).toContainEqual({ from: 'MOD-A', to: 'MOD-B' });
+    expect(ruleSet.dependencyEdges).toContainEqual({ from: 'MOD-B', to: 'MOD-C' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkFileOwnership
+// ---------------------------------------------------------------------------
+
+describe('checkFileOwnership', () => {
+  it('TEST-019: returns allowed=true for path in ownedFiles', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkFileOwnership(ruleSet, 'src/a/index.ts');
+    expect(result.allowed).toBe(true);
+    expect(result.violation).toBeNull();
+  });
+
+  it('TEST-019: returns correct owningModuleId when path belongs to another module', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkFileOwnership(ruleSet, 'src/b/index.ts');
+    expect(result.allowed).toBe(false);
+    expect(result.violation).not.toBeNull();
+    expect(result.violation!.owningModuleId).toBe('MOD-B');
+    expect(result.violation!.ruleType).toBe('file_ownership');
+  });
+
+  it('returns owningModuleId=null when path not owned by any module', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkFileOwnership(ruleSet, 'src/unknown/file.ts');
+    expect(result.allowed).toBe(false);
+    expect(result.violation!.owningModuleId).toBeNull();
+  });
+
+  it('violation includes non-empty suggestedFix', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkFileOwnership(ruleSet, 'src/b/index.ts');
+    expect(result.violation!.suggestedFix).toBeTruthy();
+    expect(result.violation!.suggestedFix.length).toBeGreaterThan(0);
+  });
+
+  it('normalizes path with backslashes before checking', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkFileOwnership(ruleSet, 'src\\a\\index.ts');
+    expect(result.allowed).toBe(true);
+  });
+
+  it('handles glob-style /** owned_files pattern', () => {
+    const ruleSet = buildRuleSet({
+      ownedFiles: ['src/constraint/**'],
+      allModules: [{ id: 'MOD-A', ownedFiles: ['src/constraint/**'] }],
+    });
+    const result = checkFileOwnership(ruleSet, 'src/constraint/rule-engine.ts');
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateImport
+// ---------------------------------------------------------------------------
+
+describe('validateImport', () => {
+  it('TEST-020: allows import along valid dependency edge', () => {
+    const ruleSet = buildRuleSet();
+    // MOD-A -> MOD-B is allowed
+    const result = validateImport(ruleSet, 'src/a/index.ts', 'src/b/index.ts');
+    expect(result.allowed).toBe(true);
+    expect(result.violation).toBeNull();
+  });
+
+  it('TEST-020: blocks import with no dependency edge', () => {
+    const ruleSet = buildRuleSet();
+    // MOD-B -> MOD-A is NOT in edges
+    const result = validateImport(ruleSet, 'src/b/index.ts', 'src/a/index.ts');
+    expect(result.allowed).toBe(false);
+    expect(result.violation!.ruleType).toBe('import_direction');
+  });
+
+  it('TEST-020: violation suggestedFix mentions allowed dependencies', () => {
+    const ruleSet = buildRuleSet();
+    const result = validateImport(ruleSet, 'src/b/index.ts', 'src/a/index.ts');
+    expect(result.violation!.suggestedFix).toContain('MOD-C');
+  });
+
+  it('throws UNRESOLVABLE_PATH for unknown source path', () => {
+    const ruleSet = buildRuleSet();
+    expect(() => validateImport(ruleSet, 'src/unknown/file.ts', 'src/b/index.ts')).toThrow(
+      /UNRESOLVABLE_PATH/,
+    );
+  });
+
+  it('throws UNRESOLVABLE_PATH for unknown target path', () => {
+    const ruleSet = buildRuleSet();
+    expect(() => validateImport(ruleSet, 'src/a/index.ts', 'src/unknown/file.ts')).toThrow(
+      /UNRESOLVABLE_PATH/,
+    );
+  });
+
+  it('allows intra-module imports (same module)', () => {
+    const ruleSet = buildRuleSet();
+    const result = validateImport(ruleSet, 'src/a/index.ts', 'src/a/helper.ts');
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-014, TEST-015: detectCycle
+// ---------------------------------------------------------------------------
+
+describe('detectCycle', () => {
+  it('TEST-014: detects cycle when adding C->A to A->B->C graph', () => {
+    const ruleSet = buildRuleSet();
+    // Existing edges: A->B, B->C. Adding C->A would create cycle.
+    const result = detectCycle(ruleSet, 'MOD-C', 'MOD-A');
+    expect(result.hasCycle).toBe(true);
+    expect(result.cyclePath).not.toBeNull();
+    expect(result.cyclePath!).toContain('MOD-A');
+    expect(result.cyclePath!).toContain('MOD-C');
+  });
+
+  it('TEST-015: no cycle for acyclic import A->C (already reachable via A->B->C)', () => {
+    const ruleSet = buildRuleSet();
+    // Adding A->C is acyclic (C doesn't reach A)
+    const result = detectCycle(ruleSet, 'MOD-A', 'MOD-C');
+    expect(result.hasCycle).toBe(false);
+    expect(result.cyclePath).toBeNull();
+  });
+
+  it('no cycle for completely disconnected modules', () => {
+    const ruleSet = buildRuleSet({
+      dependencyEdges: [],
+    });
+    const result = detectCycle(ruleSet, 'MOD-A', 'MOD-B');
+    expect(result.hasCycle).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-022, TEST-023: checkProfileConflicts
+// ---------------------------------------------------------------------------
+
+describe('checkProfileConflicts', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  it('TEST-022: returns empty conflicts when profile file does not exist', () => {
+    const ruleSet = buildRuleSet();
+    const result = checkProfileConflicts(ruleSet, join(tmpDir, 'nonexistent.json'));
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.skippedRuleIds).toHaveLength(0);
+  });
+
+  it('TEST-022: detects conflict when profile prohibits spec-allowed import direction', () => {
+    const ruleSet = buildRuleSet();
+    const profilePath = join(tmpDir, 'l2-decisions.json');
+    writeJson(profilePath, {
+      decisions: [
+        {
+          type: 'prohibit_dependency',
+          description: 'import-direction-MOD-A-MOD-B is prohibited by architecture decision',
+        },
+      ],
+    });
+
+    const result = checkProfileConflicts(ruleSet, profilePath);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0].ruleId).toBe('import-direction-MOD-A-MOD-B');
+    expect(result.conflicts[0].resolution).toBe('pending');
+    expect(result.skippedRuleIds).toContain('import-direction-MOD-A-MOD-B');
+  });
+
+  it('TEST-023: non-conflicting rules are active when one rule has a conflict', () => {
+    const ruleSet = buildRuleSet();
+    const profilePath = join(tmpDir, 'l2-decisions.json');
+    // Only conflict with one import-direction rule
+    writeJson(profilePath, {
+      decisions: [
+        {
+          type: 'prohibit_dependency',
+          description: 'import-direction-MOD-A-MOD-B is prohibited',
+        },
+      ],
+    });
+
+    const result = checkProfileConflicts(ruleSet, profilePath);
+    // Only 1 skipped, the file_ownership and circular_dep rules are unaffected
+    expect(result.skippedRuleIds).toHaveLength(1);
+    expect(result.conflicts[0].resolution).toBe('pending');
+  });
+});

--- a/tests/constraint/tools.test.ts
+++ b/tests/constraint/tools.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for MOD-002: constraint/tools
+ * Covers TEST-003 to TEST-010, TEST-016, TEST-018, TEST-021
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  handleWriteFile,
+  handleValidateImport,
+  handleReadConstraints,
+} from '../../src/constraint/tools.js';
+import { buildReport, writeReport } from '../../src/constraint/reporter.js';
+import type { SessionState, ConstraintRuleSet } from '../../src/constraint/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'tools-test-'));
+}
+
+function makeRuleSet(overrides?: Partial<ConstraintRuleSet>): ConstraintRuleSet {
+  return {
+    moduleId: 'MOD-001',
+    ownedFiles: ['src/constraint/**'],
+    allowedDependencies: [{ moduleId: 'MOD-002', ownedFiles: ['src/lash/**'] }],
+    allModules: [
+      { id: 'MOD-001', ownedFiles: ['src/constraint/**'] },
+      { id: 'MOD-002', ownedFiles: ['src/lash/**'] },
+      { id: 'MOD-003', ownedFiles: ['src/other/**'] },
+    ],
+    dependencyEdges: [
+      { from: 'MOD-001', to: 'MOD-002' },
+    ],
+    rules: [
+      { id: 'file-ownership-MOD-001', type: 'file_ownership', moduleId: 'MOD-001', description: 'file ownership' },
+      { id: 'import-direction-MOD-001-MOD-002', type: 'import_direction', moduleId: 'MOD-001', description: 'import direction' },
+      { id: 'circular-dep-MOD-001', type: 'circular_dep', moduleId: 'MOD-001', description: 'circular dep' },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSessionState(workDir: string, overrides?: Partial<ConstraintRuleSet>): SessionState {
+  return {
+    ruleSet: makeRuleSet(overrides),
+    violations: [],
+    mcpCallCount: 0,
+    violationsBlockedCount: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TEST-003: nopilot_write_file succeeds for owned path
+// ---------------------------------------------------------------------------
+
+describe('handleWriteFile', () => {
+  it('TEST-003: succeeds for path in owned_files', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    const result = handleWriteFile(state, workDir, {
+      file_path: 'src/constraint/rule-engine.ts',
+      content: 'export {}',
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Written:');
+    expect(existsSync(join(workDir, 'src/constraint/rule-engine.ts'))).toBe(true);
+    expect(state.mcpCallCount).toBe(1);
+  });
+
+  it('TEST-004: blocks write to non-owned path, no bytes written', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+    const targetPath = join(workDir, 'src/lash/other-module.ts');
+
+    const result = handleWriteFile(state, workDir, {
+      file_path: 'src/lash/other-module.ts',
+      content: 'export {}',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(existsSync(targetPath)).toBe(false);
+    expect(state.violations).toHaveLength(1);
+    expect(state.violationsBlockedCount).toBe(1);
+  });
+
+  it('TEST-005: all non-owned paths blocked equally — dep files, transitive, unrelated', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    // Direct dep file
+    const r1 = handleWriteFile(state, workDir, { file_path: 'src/lash/file.ts', content: '' });
+    // Transitive dep file (MOD-003 not in edges from MOD-001)
+    const r2 = handleWriteFile(state, workDir, { file_path: 'src/other/file.ts', content: '' });
+    // Completely unrelated file
+    const r3 = handleWriteFile(state, workDir, { file_path: 'src/random/file.ts', content: '' });
+
+    expect(r1.isError).toBe(true);
+    expect(r2.isError).toBe(true);
+    expect(r3.isError).toBe(true);
+  });
+
+  it('TEST-016: blocked write produces zero bytes — file does not exist after violation', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+    const targetPath = join(workDir, 'src/lash/should-not-exist.ts');
+
+    // Ensure it doesn't exist before
+    expect(existsSync(targetPath)).toBe(false);
+
+    handleWriteFile(state, workDir, { file_path: 'src/lash/should-not-exist.ts', content: 'data' });
+
+    // Must still not exist after violation
+    expect(existsSync(targetPath)).toBe(false);
+  });
+
+  it('TEST-018: ConstraintViolation contains all required fields', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    const result = handleWriteFile(state, workDir, {
+      file_path: 'src/lash/blocked.ts',
+      content: 'x',
+    });
+
+    expect(result.isError).toBe(true);
+    const violation = JSON.parse(result.content[0].text);
+    expect(violation).toHaveProperty('ruleId');
+    expect(violation).toHaveProperty('ruleType');
+    expect(violation).toHaveProperty('violatingPath');
+    expect(violation).toHaveProperty('owningModuleId');
+    expect(violation).toHaveProperty('suggestedFix');
+    expect(violation.ruleId).toBeTruthy();
+    expect(violation.suggestedFix).toBeTruthy();
+  });
+
+  it('increments mcpCallCount on each call (allowed or blocked)', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    handleWriteFile(state, workDir, { file_path: 'src/constraint/a.ts', content: '' });
+    handleWriteFile(state, workDir, { file_path: 'src/lash/b.ts', content: '' });
+
+    expect(state.mcpCallCount).toBe(2);
+  });
+
+  it('TEST-035: normalizes path with backslashes before checking', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    // backslash path — should still match src/constraint/**
+    const result = handleWriteFile(state, workDir, {
+      file_path: 'src\\constraint\\rule-engine.ts',
+      content: 'export {}',
+    });
+    expect(result.isError).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-006 to TEST-008: nopilot_validate_import
+// ---------------------------------------------------------------------------
+
+describe('handleValidateImport', () => {
+  it('TEST-006: allows import along valid dependency edge (MOD-001 -> MOD-002)', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    const result = handleValidateImport(state, {
+      source_path: 'src/constraint/server.ts',
+      import_target_path: 'src/lash/spec-resolver.ts',
+    });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.allowed).toBe(true);
+    expect(parsed.violation).toBeNull();
+  });
+
+  it('TEST-007: denies import with no dependency edge (MOD-002 -> MOD-001)', () => {
+    const workDir = makeTmpDir();
+    // Build state as MOD-002 (which has no edge to MOD-001)
+    const state: SessionState = {
+      ruleSet: makeRuleSet({
+        moduleId: 'MOD-002',
+        ownedFiles: ['src/lash/**'],
+        allowedDependencies: [],
+        dependencyEdges: [{ from: 'MOD-001', to: 'MOD-002' }],
+        rules: [
+          { id: 'file-ownership-MOD-002', type: 'file_ownership', moduleId: 'MOD-002', description: '' },
+        ],
+      }),
+      violations: [],
+      mcpCallCount: 0,
+      violationsBlockedCount: 0,
+    };
+
+    const result = handleValidateImport(state, {
+      source_path: 'src/lash/spec-resolver.ts',
+      import_target_path: 'src/constraint/rule-engine.ts',
+    });
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.allowed).toBe(false);
+    expect(parsed.violation.ruleType).toBe('import_direction');
+  });
+
+  it('TEST-008: returns error for unresolvable source path', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    const result = handleValidateImport(state, {
+      source_path: 'src/unknown/file.ts',
+      import_target_path: 'src/constraint/rule-engine.ts',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe('UNRESOLVABLE_PATH');
+  });
+
+  it('increments mcpCallCount', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+    handleValidateImport(state, {
+      source_path: 'src/constraint/server.ts',
+      import_target_path: 'src/lash/spec-resolver.ts',
+    });
+    expect(state.mcpCallCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-009, TEST-010: nopilot_read_constraints
+// ---------------------------------------------------------------------------
+
+describe('handleReadConstraints', () => {
+  it('TEST-009: returns full ConstraintRuleSet summary', () => {
+    const state = makeSessionState(makeTmpDir());
+
+    const result = handleReadConstraints(state);
+
+    expect(result.isError).toBe(false);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.moduleId).toBe('MOD-001');
+    expect(Array.isArray(parsed.ownedFiles)).toBe(true);
+    expect(Array.isArray(parsed.allowedDependencies)).toBe(true);
+    expect(typeof parsed.ruleCount).toBe('number');
+    expect(parsed.ruleCount).toBeGreaterThan(0);
+  });
+
+  it('TEST-010: returns error when no module context (null state)', () => {
+    const result = handleReadConstraints(null);
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe('NO_MODULE_CONTEXT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEST-021: constraint-report.json written with correct counters
+// ---------------------------------------------------------------------------
+
+describe('buildReport + writeReport', () => {
+  it('TEST-021: report contains correct counters after 3 MCP calls (2 allowed, 1 blocked)', () => {
+    const workDir = makeTmpDir();
+    const state = makeSessionState(workDir);
+
+    // 2 allowed writes
+    handleWriteFile(state, workDir, { file_path: 'src/constraint/a.ts', content: '' });
+    handleWriteFile(state, workDir, { file_path: 'src/constraint/b.ts', content: '' });
+    // 1 blocked write
+    handleWriteFile(state, workDir, { file_path: 'src/lash/blocked.ts', content: '' });
+
+    const report = buildReport(state);
+    expect(report.moduleId).toBe('MOD-001');
+    expect(report.counters.mcpCalls).toBe(3);
+    expect(report.counters.violationsBlocked).toBe(1);
+    expect(report.violations).toHaveLength(1);
+    expect(report.timestamp).toBeTruthy();
+
+    // Write the report and verify the file exists
+    const reportPath = writeReport(workDir, report);
+    expect(existsSync(reportPath)).toBe(true);
+  });
+
+  it('report timestamp is ISO 8601', () => {
+    const state = makeSessionState(makeTmpDir());
+    const report = buildReport(state);
+    expect(() => new Date(report.timestamp)).not.toThrow();
+    expect(new Date(report.timestamp).toISOString()).toBe(report.timestamp);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/constraint/` module implementing MCP-based constraint enforcement for Lash Workers
- MCP server (stdio transport) exposes 3 tools: `nopilot_write_file`, `nopilot_validate_import`, `nopilot_read_constraints`
- Rule engine extracts constraint rules from `spec.json` (owned_files + dependency_graph) — zero manual config
- Per-platform MCP config generation for Claude Code, Codex, and OpenCode
- Pure blocking mode: violating writes are rejected before any bytes hit disk
- 55 tests added across 3 test files (25 + 15 + 15), 863 total tests passing

## Architecture

```
Agent → [nopilot_write_file] → ConstraintServer (stdio)
                                    ↓
                              RuleEngine.checkFileOwnership()
                                    ↓
                           allowed? → write to disk
                           denied?  → ConstraintViolation (isError:true)
```

## Key Design Decisions

- **Pure MCP approach** — no platform hooks, no private APIs
- **stdio transport** — lifecycle auto-bound to agent process (no orphan processes)
- **Write proxy pattern** — server validates then executes writes (single tool call)
- **Path-level import validation** (V1) — AST-level scanning deferred to V2
- **Post-check fallback** — existing `checkUnexpectedFiles()` catches MCP bypass

## Test plan

- [x] 55 constraint module tests passing
- [x] Full suite: 863 tests, 0 failures
- [x] TypeScript build: 0 errors
- [x] Lash build pipeline: tracer + batch + verification all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)